### PR TITLE
Modifying GBD query and calculations for improved performance

### DIFF
--- a/BenMAP/Tools/GBDRollback.cs
+++ b/BenMAP/Tools/GBDRollback.cs
@@ -995,7 +995,9 @@ namespace BenMAP
                     if ((dtGBDDataByGridCell != null) && (dtGBDDataByGridCell.Rows.Count > 0))
                     {
                         //add baseline mortality column
-                        dtGBDDataByGridCell.Columns.Add("BASELINE_MORTALITY", dtGBDDataByGridCell.Columns["CONCENTRATION"].DataType, "INCIDENCERATE * POPESTIMATE");                       
+                        // IEc-Temporarily using preprocessed population*incident rate done in the coord SQL query. Therefore, removed population from this calculation
+                        //dtGBDDataByGridCell.Columns.Add("BASELINE_MORTALITY", dtGBDDataByGridCell.Columns["CONCENTRATION"].DataType, "INCIDENCERATE * POPESTIMATE");                       
+                        dtGBDDataByGridCell.Columns.Add("BASELINE_MORTALITY", dtGBDDataByGridCell.Columns["CONCENTRATION"].DataType, "INCIDENCERATE");
 
                         // run rollback, NOTE: this will add rollback columns
                         DoRollback(rollback);

--- a/BenMAP/Tools/GBDRollbackDataSource.cs
+++ b/BenMAP/Tools/GBDRollbackDataSource.cs
@@ -258,25 +258,69 @@ namespace BenMAP
             try
             {
                 ESIL.DBUtility.FireBirdHelperBase fb = new ESIL.DBUtility.ESILFireBirdHelper();
-                string commandText =
-                "select cc.COORDID, r.REGIONID, r.REGIONNAME, c.COUNTRYNUM,  " +
-                "c.COUNTRYID, c.COUNTRYNAME, endpt.ENDPOINTNAME, age.AGERANGENAME,  " +
-                "gen.GENDERNAME, pv.CONCENTRATION, pop.POPESTIMATE, inc.INCIDENCERATE " +
-                "from REGIONS r " +
-                "inner join REGIONCOUNTRIES rc on r.REGIONID = rc.REGIONID " +
-                "inner join COUNTRIES c on rc.COUNTRYID = c.COUNTRYID " +
-                "inner join COUNTRYCOORDINATES cc on c.COUNTRYID = cc.COUNTRYID " +
-                "inner join POLLUTANTVALUES pv on cc.COORDID = pv.COORDID " +
-                "inner join POPULATION pop on pv.COORDID = pop.COORDID " +
-                "inner join GENDERS gen on gen.GENDERID = pop.GENDERID " +
-                "inner join AGERANGES age on age.AGERANGEID = pop.AGERANGEID " +
-                "inner join INCIDENCERATES inc on inc.AGERANGEID = pop.AGERANGEID " +
-                    "and inc.GENDERID = pop.GENDERID and inc.COUNTRYID = c.COUNTRYID " +
-                "inner join ENDPOINTS endpt on endpt.ENDPOINTID = inc.ENDPOINTID " +
-                "inner join BETACOEFFICIENTS betas on betas.ENDPOINTID = endpt.ENDPOINTID " +
-                "inner join FUNCTIONS fun on fun.FUNCTIONID = betas.FUNCTIONID " +
-                "where fun.FUNCTIONID = " + functionID + " and c.COUNTRYID = '" + countryID + "' and pv.POLLUTANTID = " + pollutantID + " " +
-                    "and cc.COORDID = " + coordID + " and pop.YEARNUM = '2015' and pv.YEARNUM = '2013' ";
+                /*
+                                string commandText =
+                                "select cc.COORDID, r.REGIONID, r.REGIONNAME, c.COUNTRYNUM,  " +
+                                "c.COUNTRYID, c.COUNTRYNAME, endpt.ENDPOINTNAME, age.AGERANGENAME,  " +
+                                "gen.GENDERNAME, pv.CONCENTRATION, pop.POPESTIMATE, inc.INCIDENCERATE " +
+                                "from REGIONS r " +
+                                "inner join REGIONCOUNTRIES rc on r.REGIONID = rc.REGIONID " +
+                                "inner join COUNTRIES c on rc.COUNTRYID = c.COUNTRYID " +
+                                "inner join COUNTRYCOORDINATES cc on c.COUNTRYID = cc.COUNTRYID " +
+                                "inner join POLLUTANTVALUES pv on cc.COORDID = pv.COORDID " +
+                                "inner join POPULATION pop on pv.COORDID = pop.COORDID " +
+                                "inner join GENDERS gen on gen.GENDERID = pop.GENDERID " +
+                                "inner join AGERANGES age on age.AGERANGEID = pop.AGERANGEID " +
+                                "inner join INCIDENCERATES inc on inc.AGERANGEID = pop.AGERANGEID " +
+                                    "and inc.GENDERID = pop.GENDERID and inc.COUNTRYID = c.COUNTRYID " +
+                                "inner join ENDPOINTS endpt on endpt.ENDPOINTID = inc.ENDPOINTID " +
+                                "inner join BETACOEFFICIENTS betas on betas.ENDPOINTID = endpt.ENDPOINTID " +
+                                "inner join FUNCTIONS fun on fun.FUNCTIONID = betas.FUNCTIONID " +
+                                "where fun.FUNCTIONID = " + functionID + " and c.COUNTRYID = '" + countryID + "' and pv.POLLUTANTID = " + pollutantID + " " +
+                                    "and cc.COORDID = " + coordID + " and pop.YEARNUM = '2015' and pv.YEARNUM = '2013' ";
+                */
+                // Temorarily using a SQL query that aggregates all the endpoints, genders, and age ranges together to improve performance
+                string commandText = @"
+with p as (SELECT a.coordid, sum(b.POPESTIMATE) POPESTIMATE
+FROM COUNTRYCOORDINATES a
+join POPULATION b on a.COORDID = b.COORDID
+where a.COUNTRYID = '" + countryID + @"'
+and a.COORDID = " + coordID + @"
+group by 1
+) 
+                select 
+                cc.COORDID
+                , r.REGIONID
+                , r.REGIONNAME
+                , c.COUNTRYNUM
+                , c.COUNTRYID
+                , c.COUNTRYNAME
+                , 'Mortality, All' ENDPOINTNAME -- endpt.ENDPOINTNAME
+                , 'ALL AGE' AGERANGENAME -- age.AGERANGENAME
+                , 'ALL GENDER' GENDERNAME -- gen.GENDERNAME
+                , pv.CONCENTRATION
+                , p.POPESTIMATE
+                , sum(pop.POPESTIMATE * inc.INCIDENCERATE ) INCIDENCERATE
+                from REGIONS r 
+                inner join REGIONCOUNTRIES rc on r.REGIONID = rc.REGIONID 
+                inner join COUNTRIES c on rc.COUNTRYID = c.COUNTRYID 
+                inner join COUNTRYCOORDINATES cc on c.COUNTRYID = cc.COUNTRYID 
+                inner join POLLUTANTVALUES pv on cc.COORDID = pv.COORDID 
+                inner join POPULATION pop on pv.COORDID = pop.COORDID 
+                inner join GENDERS gen on gen.GENDERID = pop.GENDERID 
+                inner join AGERANGES age on age.AGERANGEID = pop.AGERANGEID 
+                inner join INCIDENCERATES inc on inc.AGERANGEID = pop.AGERANGEID 
+                    and inc.GENDERID = pop.GENDERID and inc.COUNTRYID = c.COUNTRYID 
+                inner join ENDPOINTS endpt on endpt.ENDPOINTID = inc.ENDPOINTID 
+                inner join BETACOEFFICIENTS betas on betas.ENDPOINTID = endpt.ENDPOINTID 
+                inner join FUNCTIONS fun on fun.FUNCTIONID = betas.FUNCTIONID 
+                inner join p on cc.COORDID = p.COORDID
+                where fun.FUNCTIONID = " + functionID + @" and c.COUNTRYID = '" + countryID + @"' and pv.POLLUTANTID = " + pollutantID + @"
+                    and pop.YEARNUM = 2015 and pv.YEARNUM = 2013
+                --    and pop.YEARNUM = '2015' and pv.YEARNUM = '2013'
+                    and cc.COORDID = " + coordID + @"
+                    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+					order by 1, 7, 8";
 
                 DataSet ds = fb.ExecuteDataset(GBDRollbackDataSource.Connection, CommandType.Text, commandText);
 

--- a/BenMAP/Tools/GBDRollbackKrewskiFunction.cs
+++ b/BenMAP/Tools/GBDRollbackKrewskiFunction.cs
@@ -27,16 +27,21 @@ namespace BenMAP
                     double PopIn = population[idx];
                     double incrate = incRate[idx];
 
-                    double krewski = (1 - (1 / Math.Exp(beta * ConcIn))) * PopIn * incrate;
-                    double krewski_2_5pct = (1 - (1 / Math.Exp(qnorm5(.025, beta, se, true, false) * ConcIn))) * PopIn * incrate;
-                    double krewski_97_5pct = (1 - (1 / Math.Exp(qnorm5(.975, beta, se, true, false) * ConcIn))) * PopIn * incrate;
+                    // IEc-Temporarily using preprocessed pop*inc values from the coord SQL query
+                    //double krewski = (1 - (1 / Math.Exp(beta * ConcIn))) * PopIn * incrate;
+                    //double krewski_2_5pct = (1 - (1 / Math.Exp(qnorm5(.025, beta, se, true, false) * ConcIn))) * PopIn * incrate;
+                    //double krewski_97_5pct = (1 - (1 / Math.Exp(qnorm5(.975, beta, se, true, false) * ConcIn))) * PopIn * incrate;
+                    double krewski = (1 - (1 / Math.Exp(beta * ConcIn)))  * incrate;
+                    double krewski_2_5pct = (1 - (1 / Math.Exp(qnorm5(.025, beta, se, true, false) * ConcIn)))  * incrate;
+                    double krewski_97_5pct = (1 - (1 / Math.Exp(qnorm5(.975, beta, se, true, false) * ConcIn))) * incrate;
+
                     Krewski += krewski;
                     Sum_2_5 += krewski_2_5pct;
                     Sum_97_5 += krewski_97_5pct;
                 }
-                Console.WriteLine("Krewski: " + Krewski);
-                Console.WriteLine("2.5: " + Sum_2_5);
-                Console.WriteLine("97.5: " + Sum_97_5);
+                //Console.WriteLine("Krewski: " + Krewski);
+                //Console.WriteLine("2.5: " + Sum_2_5);
+                //Console.WriteLine("97.5: " + Sum_97_5);
                 return new GBDRollbackKrewskiResult(Krewski, Sum_2_5, Sum_97_5);
             }
             catch (Exception ex)


### PR DESCRIPTION
Multiplying incidence rate and population in the database query and then summing across endpoints, age ranges, and genders before running the krewski function to improve performance. Note that the INCIDENCERATE column returned by the query now contains POPESTIMATE*INCIDENCERATE. This will be renamed and clarified in a future release. I wanted to minimize code changes at this point to reduce risk.