### PR TITLE
I ec double entry error while adding to new hif

### DIFF
--- a/BenMAP/ManageSetup/HealthImpactFunctionDefinition.Designer.cs
+++ b/BenMAP/ManageSetup/HealthImpactFunctionDefinition.Designer.cs
@@ -137,8 +137,11 @@ namespace BenMAP
             this.tbpFunction.SuspendLayout();
             this.tbpBaselineFunction.SuspendLayout();
             this.SuspendLayout();
-                                                this.grpCancelOK.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // grpCancelOK
+            // 
+            this.grpCancelOK.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.grpCancelOK.Controls.Add(this.btnOK);
             this.grpCancelOK.Controls.Add(this.btnCancel);
             this.grpCancelOK.Location = new System.Drawing.Point(10, 601);
@@ -146,7 +149,10 @@ namespace BenMAP
             this.grpCancelOK.Size = new System.Drawing.Size(781, 54);
             this.grpCancelOK.TabIndex = 1;
             this.grpCancelOK.TabStop = false;
-                                                this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // btnOK
+            // 
+            this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnOK.Location = new System.Drawing.Point(684, 20);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 27);
@@ -154,7 +160,10 @@ namespace BenMAP
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
-                                                this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.Location = new System.Drawing.Point(603, 20);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 27);
@@ -162,8 +171,11 @@ namespace BenMAP
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-                                                this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel1.ColumnCount = 3;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 24.9313F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 34.90381F));
@@ -177,7 +189,10 @@ namespace BenMAP
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(778, 350);
             this.tableLayoutPanel1.TabIndex = 24;
-                                                this.grpParameter1.Controls.Add(this.tableLayoutPanel3);
+            // 
+            // grpParameter1
+            // 
+            this.grpParameter1.Controls.Add(this.tableLayoutPanel3);
             this.grpParameter1.Controls.Add(this.cboVariableDataSet);
             this.grpParameter1.Controls.Add(this.lblVariableDataSet);
             this.grpParameter1.Controls.Add(this.cboPrevalenceDataSet);
@@ -190,8 +205,11 @@ namespace BenMAP
             this.grpParameter1.Size = new System.Drawing.Size(308, 344);
             this.grpParameter1.TabIndex = 4;
             this.grpParameter1.TabStop = false;
-                                                this.tableLayoutPanel3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel3.ColumnCount = 2;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 54.54546F));
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45.45454F));
@@ -203,7 +221,10 @@ namespace BenMAP
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(299, 196);
             this.tableLayoutPanel3.TabIndex = 2;
-                                                this.panel4.Controls.Add(this.lblBetaDisribution);
+            // 
+            // panel4
+            // 
+            this.panel4.Controls.Add(this.lblBetaDisribution);
             this.panel4.Controls.Add(this.lblConstantDescription);
             this.panel4.Controls.Add(this.txtBetaParameter1);
             this.panel4.Controls.Add(this.lblBetaParameter1);
@@ -219,77 +240,113 @@ namespace BenMAP
             this.panel4.Name = "panel4";
             this.panel4.Size = new System.Drawing.Size(157, 190);
             this.panel4.TabIndex = 0;
-                                                this.lblBetaDisribution.AutoSize = true;
+            // 
+            // lblBetaDisribution
+            // 
+            this.lblBetaDisribution.AutoSize = true;
             this.lblBetaDisribution.Location = new System.Drawing.Point(21, 1);
             this.lblBetaDisribution.Name = "lblBetaDisribution";
             this.lblBetaDisribution.Size = new System.Drawing.Size(103, 14);
             this.lblBetaDisribution.TabIndex = 0;
             this.lblBetaDisribution.Text = "Beta Distribution:";
-                                                this.lblConstantDescription.AutoSize = true;
+            // 
+            // lblConstantDescription
+            // 
+            this.lblConstantDescription.AutoSize = true;
             this.lblConstantDescription.Location = new System.Drawing.Point(23, 92);
             this.lblConstantDescription.Name = "lblConstantDescription";
             this.lblConstantDescription.Size = new System.Drawing.Size(123, 14);
             this.lblConstantDescription.TabIndex = 0;
             this.lblConstantDescription.Text = "Constant Description:";
-                                                this.txtBetaParameter1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtBetaParameter1
+            // 
+            this.txtBetaParameter1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBetaParameter1.Location = new System.Drawing.Point(25, 64);
             this.txtBetaParameter1.Name = "txtBetaParameter1";
             this.txtBetaParameter1.Size = new System.Drawing.Size(126, 22);
             this.txtBetaParameter1.TabIndex = 6;
             this.txtBetaParameter1.Text = "0";
             this.txtBetaParameter1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtBetaParameter1_KeyPress);
-                                                this.lblBetaParameter1.AutoSize = true;
+            // 
+            // lblBetaParameter1
+            // 
+            this.lblBetaParameter1.AutoSize = true;
             this.lblBetaParameter1.Location = new System.Drawing.Point(23, 48);
             this.lblBetaParameter1.Name = "lblBetaParameter1";
             this.lblBetaParameter1.Size = new System.Drawing.Size(100, 14);
             this.lblBetaParameter1.TabIndex = 2;
             this.lblBetaParameter1.Text = "Beta Parameter1:";
-                                                this.txtAconstantDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtAconstantDescription
+            // 
+            this.txtAconstantDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtAconstantDescription.Location = new System.Drawing.Point(25, 109);
             this.txtAconstantDescription.Name = "txtAconstantDescription";
             this.txtAconstantDescription.Size = new System.Drawing.Size(126, 22);
             this.txtAconstantDescription.TabIndex = 2;
-                                                this.lblC.AutoSize = true;
+            // 
+            // lblC
+            // 
+            this.lblC.AutoSize = true;
             this.lblC.Location = new System.Drawing.Point(3, 168);
             this.lblC.Name = "lblC";
             this.lblC.Size = new System.Drawing.Size(16, 14);
             this.lblC.TabIndex = 10;
             this.lblC.Text = "C:";
-                                                this.lblA.AutoSize = true;
+            // 
+            // lblA
+            // 
+            this.lblA.AutoSize = true;
             this.lblA.Location = new System.Drawing.Point(3, 113);
             this.lblA.Name = "lblA";
             this.lblA.Size = new System.Drawing.Size(17, 14);
             this.lblA.TabIndex = 8;
             this.lblA.Text = "A:";
-                                                this.txtCconstantDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtCconstantDescription
+            // 
+            this.txtCconstantDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtCconstantDescription.Location = new System.Drawing.Point(25, 164);
             this.txtCconstantDescription.Name = "txtCconstantDescription";
             this.txtCconstantDescription.Size = new System.Drawing.Size(126, 22);
             this.txtCconstantDescription.TabIndex = 6;
-                                                this.lblB.AutoSize = true;
+            // 
+            // lblB
+            // 
+            this.lblB.AutoSize = true;
             this.lblB.Location = new System.Drawing.Point(3, 141);
             this.lblB.Name = "lblB";
             this.lblB.Size = new System.Drawing.Size(17, 14);
             this.lblB.TabIndex = 9;
             this.lblB.Text = "B:";
-                                                this.txtBconstantDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtBconstantDescription
+            // 
+            this.txtBconstantDescription.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBconstantDescription.Location = new System.Drawing.Point(25, 136);
             this.txtBconstantDescription.Name = "txtBconstantDescription";
             this.txtBconstantDescription.Size = new System.Drawing.Size(126, 22);
             this.txtBconstantDescription.TabIndex = 4;
-                                                this.cboBetaDistribution.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboBetaDistribution
+            // 
+            this.cboBetaDistribution.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboBetaDistribution.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboBetaDistribution.FormattingEnabled = true;
             this.cboBetaDistribution.Location = new System.Drawing.Point(22, 17);
             this.cboBetaDistribution.Name = "cboBetaDistribution";
             this.cboBetaDistribution.Size = new System.Drawing.Size(126, 22);
             this.cboBetaDistribution.TabIndex = 4;
-                                                this.panel5.Controls.Add(this.lblBeta);
+            // 
+            // panel5
+            // 
+            this.panel5.Controls.Add(this.lblBeta);
             this.panel5.Controls.Add(this.txtBetaParameter2);
             this.panel5.Controls.Add(this.txtBconstantValue);
             this.panel5.Controls.Add(this.txtAconstantValue);
@@ -302,107 +359,152 @@ namespace BenMAP
             this.panel5.Name = "panel5";
             this.panel5.Size = new System.Drawing.Size(130, 190);
             this.panel5.TabIndex = 1;
-                                                this.lblBeta.AutoSize = true;
+            // 
+            // lblBeta
+            // 
+            this.lblBeta.AutoSize = true;
             this.lblBeta.Location = new System.Drawing.Point(3, 0);
             this.lblBeta.Name = "lblBeta";
             this.lblBeta.Size = new System.Drawing.Size(35, 14);
             this.lblBeta.TabIndex = 1;
             this.lblBeta.Text = "Beta:";
-                                                this.txtBetaParameter2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtBetaParameter2
+            // 
+            this.txtBetaParameter2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBetaParameter2.Location = new System.Drawing.Point(5, 63);
             this.txtBetaParameter2.Name = "txtBetaParameter2";
             this.txtBetaParameter2.Size = new System.Drawing.Size(123, 22);
             this.txtBetaParameter2.TabIndex = 7;
             this.txtBetaParameter2.Text = "0";
             this.txtBetaParameter2.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtBetaParameter2_KeyPress);
-                                                this.txtBconstantValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtBconstantValue
+            // 
+            this.txtBconstantValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBconstantValue.Location = new System.Drawing.Point(5, 135);
             this.txtBconstantValue.Name = "txtBconstantValue";
             this.txtBconstantValue.Size = new System.Drawing.Size(123, 22);
             this.txtBconstantValue.TabIndex = 5;
             this.txtBconstantValue.Text = "0";
             this.txtBconstantValue.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtBconstantValue_KeyPress);
-                                                this.txtAconstantValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtAconstantValue
+            // 
+            this.txtAconstantValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtAconstantValue.Location = new System.Drawing.Point(5, 107);
             this.txtAconstantValue.Name = "txtAconstantValue";
             this.txtAconstantValue.Size = new System.Drawing.Size(123, 22);
             this.txtAconstantValue.TabIndex = 3;
             this.txtAconstantValue.Text = "0";
             this.txtAconstantValue.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtAconstantValue_KeyPress);
-                                                this.txtBeta.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtBeta
+            // 
+            this.txtBeta.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBeta.Location = new System.Drawing.Point(5, 15);
             this.txtBeta.Name = "txtBeta";
             this.txtBeta.Size = new System.Drawing.Size(123, 22);
             this.txtBeta.TabIndex = 5;
             this.txtBeta.Text = "0";
             this.txtBeta.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtBeta_KeyPress);
-                                                this.txtCconstantValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtCconstantValue
+            // 
+            this.txtCconstantValue.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtCconstantValue.Location = new System.Drawing.Point(5, 163);
             this.txtCconstantValue.Name = "txtCconstantValue";
             this.txtCconstantValue.Size = new System.Drawing.Size(123, 22);
             this.txtCconstantValue.TabIndex = 7;
             this.txtCconstantValue.Text = "0";
             this.txtCconstantValue.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtCconstantValue_KeyPress);
-                                                this.lblConstantValue.AutoSize = true;
+            // 
+            // lblConstantValue
+            // 
+            this.lblConstantValue.AutoSize = true;
             this.lblConstantValue.Location = new System.Drawing.Point(3, 91);
             this.lblConstantValue.Name = "lblConstantValue";
             this.lblConstantValue.Size = new System.Drawing.Size(92, 14);
             this.lblConstantValue.TabIndex = 1;
             this.lblConstantValue.Text = "Constant Value:";
-                                                this.lblBetaParameter2.AutoSize = true;
+            // 
+            // lblBetaParameter2
+            // 
+            this.lblBetaParameter2.AutoSize = true;
             this.lblBetaParameter2.Location = new System.Drawing.Point(3, 47);
             this.lblBetaParameter2.Name = "lblBetaParameter2";
             this.lblBetaParameter2.Size = new System.Drawing.Size(100, 14);
             this.lblBetaParameter2.TabIndex = 3;
             this.lblBetaParameter2.Text = "Beta Parameter2:";
-                                                this.cboVariableDataSet.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboVariableDataSet
+            // 
+            this.cboVariableDataSet.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboVariableDataSet.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboVariableDataSet.FormattingEnabled = true;
             this.cboVariableDataSet.Location = new System.Drawing.Point(35, 270);
             this.cboVariableDataSet.Name = "cboVariableDataSet";
             this.cboVariableDataSet.Size = new System.Drawing.Size(265, 22);
             this.cboVariableDataSet.TabIndex = 17;
-                                                this.lblVariableDataSet.AutoSize = true;
+            // 
+            // lblVariableDataSet
+            // 
+            this.lblVariableDataSet.AutoSize = true;
             this.lblVariableDataSet.Location = new System.Drawing.Point(32, 251);
             this.lblVariableDataSet.Name = "lblVariableDataSet";
             this.lblVariableDataSet.Size = new System.Drawing.Size(102, 14);
             this.lblVariableDataSet.TabIndex = 14;
-            this.lblVariableDataSet.Text = "Variable DataSet:";
-                                                this.cboPrevalenceDataSet.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblVariableDataSet.Text = "Variable Dataset:";
+            // 
+            // cboPrevalenceDataSet
+            // 
+            this.cboPrevalenceDataSet.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboPrevalenceDataSet.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboPrevalenceDataSet.FormattingEnabled = true;
             this.cboPrevalenceDataSet.Location = new System.Drawing.Point(35, 314);
             this.cboPrevalenceDataSet.Name = "cboPrevalenceDataSet";
             this.cboPrevalenceDataSet.Size = new System.Drawing.Size(265, 22);
             this.cboPrevalenceDataSet.TabIndex = 16;
-                                                this.lblPrevalenceDataSet.AutoSize = true;
+            // 
+            // lblPrevalenceDataSet
+            // 
+            this.lblPrevalenceDataSet.AutoSize = true;
             this.lblPrevalenceDataSet.Location = new System.Drawing.Point(31, 297);
             this.lblPrevalenceDataSet.Name = "lblPrevalenceDataSet";
             this.lblPrevalenceDataSet.Size = new System.Drawing.Size(115, 14);
             this.lblPrevalenceDataSet.TabIndex = 12;
-            this.lblPrevalenceDataSet.Text = "Prevalence DataSet:";
-                                                this.cboIncidenceDataSet.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblPrevalenceDataSet.Text = "Prevalence Dataset:";
+            // 
+            // cboIncidenceDataSet
+            // 
+            this.cboIncidenceDataSet.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboIncidenceDataSet.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboIncidenceDataSet.FormattingEnabled = true;
             this.cboIncidenceDataSet.Location = new System.Drawing.Point(34, 222);
             this.cboIncidenceDataSet.Name = "cboIncidenceDataSet";
             this.cboIncidenceDataSet.Size = new System.Drawing.Size(266, 22);
             this.cboIncidenceDataSet.TabIndex = 15;
-                                                this.lblIncidenceDataSet.AutoSize = true;
+            // 
+            // lblIncidenceDataSet
+            // 
+            this.lblIncidenceDataSet.AutoSize = true;
             this.lblIncidenceDataSet.Location = new System.Drawing.Point(30, 204);
             this.lblIncidenceDataSet.Name = "lblIncidenceDataSet";
             this.lblIncidenceDataSet.Size = new System.Drawing.Size(109, 14);
             this.lblIncidenceDataSet.TabIndex = 13;
             this.lblIncidenceDataSet.Text = "Incidence Dataset:";
-                                                this.grpParameter.Controls.Add(this.tableLayoutPanel2);
+            // 
+            // grpParameter
+            // 
+            this.grpParameter.Controls.Add(this.tableLayoutPanel2);
             this.grpParameter.Controls.Add(this.txtReference);
             this.grpParameter.Controls.Add(this.txtOtherPollutant);
             this.grpParameter.Controls.Add(this.lblReference);
@@ -413,8 +515,11 @@ namespace BenMAP
             this.grpParameter.Size = new System.Drawing.Size(265, 344);
             this.grpParameter.TabIndex = 3;
             this.grpParameter.TabStop = false;
-                                                this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tableLayoutPanel2.ColumnCount = 2;
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
@@ -426,7 +531,10 @@ namespace BenMAP
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel2.Size = new System.Drawing.Size(255, 244);
             this.tableLayoutPanel2.TabIndex = 2;
-                                                this.panel2.Controls.Add(this.label9);
+            // 
+            // panel2
+            // 
+            this.panel2.Controls.Add(this.label9);
             this.panel2.Controls.Add(this.lblRace);
             this.panel2.Controls.Add(this.cboLocationName);
             this.panel2.Controls.Add(this.lblEthnicity);
@@ -441,76 +549,109 @@ namespace BenMAP
             this.panel2.Name = "panel2";
             this.panel2.Size = new System.Drawing.Size(121, 238);
             this.panel2.TabIndex = 0;
-                                                this.label9.AutoSize = true;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(3, 146);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(87, 14);
+            this.label9.Size = new System.Drawing.Size(90, 14);
             this.label9.TabIndex = 23;
             this.label9.Text = "Location Name:";
-                                                this.lblRace.AutoSize = true;
+            // 
+            // lblRace
+            // 
+            this.lblRace.AutoSize = true;
             this.lblRace.Location = new System.Drawing.Point(3, 0);
             this.lblRace.Name = "lblRace";
             this.lblRace.Size = new System.Drawing.Size(36, 14);
             this.lblRace.TabIndex = 0;
             this.lblRace.Text = "Race:";
-                                                this.cboLocationName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboLocationName
+            // 
+            this.cboLocationName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboLocationName.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboLocationName.FormattingEnabled = true;
             this.cboLocationName.Location = new System.Drawing.Point(5, 164);
             this.cboLocationName.Name = "cboLocationName";
             this.cboLocationName.Size = new System.Drawing.Size(113, 22);
             this.cboLocationName.TabIndex = 22;
-                                                this.lblEthnicity.AutoSize = true;
+            // 
+            // lblEthnicity
+            // 
+            this.lblEthnicity.AutoSize = true;
             this.lblEthnicity.Location = new System.Drawing.Point(3, 47);
             this.lblEthnicity.Name = "lblEthnicity";
             this.lblEthnicity.Size = new System.Drawing.Size(56, 14);
             this.lblEthnicity.TabIndex = 1;
             this.lblEthnicity.Text = "Ethnicity:";
-                                                this.lblGender.AutoSize = true;
+            // 
+            // lblGender
+            // 
+            this.lblGender.AutoSize = true;
             this.lblGender.Location = new System.Drawing.Point(3, 91);
             this.lblGender.Name = "lblGender";
             this.lblGender.Size = new System.Drawing.Size(50, 14);
             this.lblGender.TabIndex = 2;
             this.lblGender.Text = "Gender:";
-                                                this.lblStartAge.AutoSize = true;
+            // 
+            // lblStartAge
+            // 
+            this.lblStartAge.AutoSize = true;
             this.lblStartAge.Location = new System.Drawing.Point(3, 191);
             this.lblStartAge.Name = "lblStartAge";
             this.lblStartAge.Size = new System.Drawing.Size(58, 14);
             this.lblStartAge.TabIndex = 8;
             this.lblStartAge.Text = "Start Age:";
-                                                this.nudownStartAge.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // nudownStartAge
+            // 
+            this.nudownStartAge.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.nudownStartAge.Location = new System.Drawing.Point(5, 209);
             this.nudownStartAge.Name = "nudownStartAge";
             this.nudownStartAge.Size = new System.Drawing.Size(113, 22);
             this.nudownStartAge.TabIndex = 19;
             this.nudownStartAge.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-                                                this.cboRace.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboRace
+            // 
+            this.cboRace.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboRace.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboRace.FormattingEnabled = true;
             this.cboRace.Location = new System.Drawing.Point(5, 17);
             this.cboRace.Name = "cboRace";
             this.cboRace.Size = new System.Drawing.Size(113, 22);
             this.cboRace.TabIndex = 11;
-                                                this.cboEthnicity.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboEthnicity
+            // 
+            this.cboEthnicity.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboEthnicity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboEthnicity.FormattingEnabled = true;
             this.cboEthnicity.Location = new System.Drawing.Point(5, 64);
             this.cboEthnicity.Name = "cboEthnicity";
             this.cboEthnicity.Size = new System.Drawing.Size(113, 22);
             this.cboEthnicity.TabIndex = 12;
-                                                this.cboGender.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboGender
+            // 
+            this.cboGender.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboGender.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboGender.FormattingEnabled = true;
             this.cboGender.Location = new System.Drawing.Point(5, 108);
             this.cboGender.Name = "cboGender";
             this.cboGender.Size = new System.Drawing.Size(113, 22);
             this.cboGender.TabIndex = 13;
-                                                this.panel3.Controls.Add(this.lblAnthor);
+            // 
+            // panel3
+            // 
+            this.panel3.Controls.Add(this.lblAnthor);
             this.panel3.Controls.Add(this.nudownEndAge);
             this.panel3.Controls.Add(this.lblLocation);
             this.panel3.Controls.Add(this.lblYear);
@@ -525,101 +666,149 @@ namespace BenMAP
             this.panel3.Name = "panel3";
             this.panel3.Size = new System.Drawing.Size(122, 238);
             this.panel3.TabIndex = 1;
-                                                this.lblAnthor.AutoSize = true;
+            // 
+            // lblAnthor
+            // 
+            this.lblAnthor.AutoSize = true;
             this.lblAnthor.Location = new System.Drawing.Point(3, 0);
             this.lblAnthor.Name = "lblAnthor";
             this.lblAnthor.Size = new System.Drawing.Size(46, 14);
             this.lblAnthor.TabIndex = 3;
             this.lblAnthor.Text = "Author:";
-                                                this.nudownEndAge.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // nudownEndAge
+            // 
+            this.nudownEndAge.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.nudownEndAge.Location = new System.Drawing.Point(6, 209);
             this.nudownEndAge.Name = "nudownEndAge";
             this.nudownEndAge.Size = new System.Drawing.Size(113, 22);
             this.nudownEndAge.TabIndex = 20;
             this.nudownEndAge.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-                                                this.lblLocation.AutoSize = true;
+            // 
+            // lblLocation
+            // 
+            this.lblLocation.AutoSize = true;
             this.lblLocation.Location = new System.Drawing.Point(3, 146);
             this.lblLocation.Name = "lblLocation";
             this.lblLocation.Size = new System.Drawing.Size(55, 14);
             this.lblLocation.TabIndex = 5;
             this.lblLocation.Text = "Location:";
-                                                this.lblYear.AutoSize = true;
+            // 
+            // lblYear
+            // 
+            this.lblYear.AutoSize = true;
             this.lblYear.Location = new System.Drawing.Point(3, 47);
             this.lblYear.Name = "lblYear";
             this.lblYear.Size = new System.Drawing.Size(111, 14);
             this.lblYear.TabIndex = 4;
             this.lblYear.Text = "Year of Publication:";
-                                                this.lblQualifier.AutoSize = true;
+            // 
+            // lblQualifier
+            // 
+            this.lblQualifier.AutoSize = true;
             this.lblQualifier.Location = new System.Drawing.Point(3, 91);
             this.lblQualifier.Name = "lblQualifier";
             this.lblQualifier.Size = new System.Drawing.Size(57, 14);
             this.lblQualifier.TabIndex = 6;
             this.lblQualifier.Text = "Qualifier:";
-                                                this.lblEndAge.AutoSize = true;
+            // 
+            // lblEndAge
+            // 
+            this.lblEndAge.AutoSize = true;
             this.lblEndAge.Location = new System.Drawing.Point(3, 191);
             this.lblEndAge.Name = "lblEndAge";
             this.lblEndAge.Size = new System.Drawing.Size(53, 14);
             this.lblEndAge.TabIndex = 9;
             this.lblEndAge.Text = "End Age:";
-                                                this.txtQualifier.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtQualifier
+            // 
+            this.txtQualifier.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtQualifier.Location = new System.Drawing.Point(6, 108);
             this.txtQualifier.Name = "txtQualifier";
             this.txtQualifier.Size = new System.Drawing.Size(113, 22);
             this.txtQualifier.TabIndex = 17;
-                                                this.txtAnthor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtAnthor
+            // 
+            this.txtAnthor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtAnthor.Location = new System.Drawing.Point(6, 16);
             this.txtAnthor.Name = "txtAnthor";
             this.txtAnthor.Size = new System.Drawing.Size(112, 22);
             this.txtAnthor.TabIndex = 14;
-                                                this.txtLocation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtLocation
+            // 
+            this.txtLocation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtLocation.Location = new System.Drawing.Point(6, 164);
             this.txtLocation.Name = "txtLocation";
             this.txtLocation.Size = new System.Drawing.Size(113, 22);
             this.txtLocation.TabIndex = 16;
-                                                this.txtYear.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtYear
+            // 
+            this.txtYear.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtYear.Location = new System.Drawing.Point(6, 63);
             this.txtYear.Name = "txtYear";
             this.txtYear.Size = new System.Drawing.Size(113, 22);
             this.txtYear.TabIndex = 15;
             this.txtYear.Text = "0";
             this.txtYear.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtYear_KeyPress);
-                                                this.txtReference.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtReference
+            // 
+            this.txtReference.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtReference.Location = new System.Drawing.Point(11, 316);
             this.txtReference.Name = "txtReference";
             this.txtReference.Size = new System.Drawing.Size(248, 22);
             this.txtReference.TabIndex = 21;
-                                                this.txtOtherPollutant.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtOtherPollutant
+            // 
+            this.txtOtherPollutant.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtOtherPollutant.Location = new System.Drawing.Point(11, 274);
             this.txtOtherPollutant.Name = "txtOtherPollutant";
             this.txtOtherPollutant.Size = new System.Drawing.Size(248, 22);
             this.txtOtherPollutant.TabIndex = 18;
-                                                this.lblReference.AutoSize = true;
+            // 
+            // lblReference
+            // 
+            this.lblReference.AutoSize = true;
             this.lblReference.Location = new System.Drawing.Point(9, 298);
             this.lblReference.Name = "lblReference";
             this.lblReference.Size = new System.Drawing.Size(65, 14);
             this.lblReference.TabIndex = 10;
             this.lblReference.Text = "Reference:";
-                                                this.lblOtherPollutant.AutoSize = true;
+            // 
+            // lblOtherPollutant
+            // 
+            this.lblOtherPollutant.AutoSize = true;
             this.lblOtherPollutant.Location = new System.Drawing.Point(8, 257);
             this.lblOtherPollutant.Name = "lblOtherPollutant";
             this.lblOtherPollutant.Size = new System.Drawing.Size(251, 14);
             this.lblOtherPollutant.TabIndex = 7;
             this.lblOtherPollutant.Text = "Co-Pollutants Specified in Regression Model:";
-                                                this.panel1.Controls.Add(this.grpEndpoint);
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.grpEndpoint);
             this.panel1.Controls.Add(this.grpMetric);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel1.Location = new System.Drawing.Point(3, 3);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(187, 344);
             this.panel1.TabIndex = 5;
-                                                this.grpEndpoint.Controls.Add(this.cboEndpoint);
+            // 
+            // grpEndpoint
+            // 
+            this.grpEndpoint.Controls.Add(this.cboEndpoint);
             this.grpEndpoint.Controls.Add(this.cboEndpointGroup);
             this.grpEndpoint.Controls.Add(this.lblEndpoint);
             this.grpEndpoint.Controls.Add(this.lblEndpointGroup);
@@ -629,16 +818,22 @@ namespace BenMAP
             this.grpEndpoint.Size = new System.Drawing.Size(187, 108);
             this.grpEndpoint.TabIndex = 1;
             this.grpEndpoint.TabStop = false;
-                                                this.cboEndpoint.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboEndpoint
+            // 
+            this.cboEndpoint.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboEndpoint.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboEndpoint.FormattingEnabled = true;
             this.cboEndpoint.Location = new System.Drawing.Point(6, 78);
             this.cboEndpoint.Name = "cboEndpoint";
             this.cboEndpoint.Size = new System.Drawing.Size(175, 22);
             this.cboEndpoint.TabIndex = 3;
-                                                this.cboEndpointGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboEndpointGroup
+            // 
+            this.cboEndpointGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboEndpointGroup.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboEndpointGroup.FormattingEnabled = true;
             this.cboEndpointGroup.Location = new System.Drawing.Point(6, 31);
@@ -646,19 +841,28 @@ namespace BenMAP
             this.cboEndpointGroup.Size = new System.Drawing.Size(175, 22);
             this.cboEndpointGroup.TabIndex = 2;
             this.cboEndpointGroup.SelectedValueChanged += new System.EventHandler(this.cboEndpointGroup_SelectedValueChanged_1);
-                                                this.lblEndpoint.AutoSize = true;
+            // 
+            // lblEndpoint
+            // 
+            this.lblEndpoint.AutoSize = true;
             this.lblEndpoint.Location = new System.Drawing.Point(6, 61);
             this.lblEndpoint.Name = "lblEndpoint";
             this.lblEndpoint.Size = new System.Drawing.Size(59, 14);
             this.lblEndpoint.TabIndex = 1;
             this.lblEndpoint.Text = "Endpoint:";
-                                                this.lblEndpointGroup.AutoSize = true;
+            // 
+            // lblEndpointGroup
+            // 
+            this.lblEndpointGroup.AutoSize = true;
             this.lblEndpointGroup.Location = new System.Drawing.Point(6, 14);
             this.lblEndpointGroup.Name = "lblEndpointGroup";
             this.lblEndpointGroup.Size = new System.Drawing.Size(95, 14);
             this.lblEndpointGroup.TabIndex = 0;
             this.lblEndpointGroup.Text = "Endpoint Group:";
-                                                this.grpMetric.Controls.Add(this.cboPercentile);
+            // 
+            // grpMetric
+            // 
+            this.grpMetric.Controls.Add(this.cboPercentile);
             this.grpMetric.Controls.Add(this.lblPercentile);
             this.grpMetric.Controls.Add(this.cboSeasonalMetric);
             this.grpMetric.Controls.Add(this.cboMetricStatistic);
@@ -674,39 +878,54 @@ namespace BenMAP
             this.grpMetric.Size = new System.Drawing.Size(187, 229);
             this.grpMetric.TabIndex = 2;
             this.grpMetric.TabStop = false;
-                                                this.cboPercentile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboPercentile
+            // 
+            this.cboPercentile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboPercentile.FormattingEnabled = true;
             this.cboPercentile.Location = new System.Drawing.Point(8, 201);
             this.cboPercentile.Name = "cboPercentile";
             this.cboPercentile.Size = new System.Drawing.Size(173, 22);
             this.cboPercentile.TabIndex = 9;
             this.cboPercentile.Visible = false;
-                                                this.lblPercentile.AutoSize = true;
+            // 
+            // lblPercentile
+            // 
+            this.lblPercentile.AutoSize = true;
             this.lblPercentile.Location = new System.Drawing.Point(8, 185);
             this.lblPercentile.Name = "lblPercentile";
             this.lblPercentile.Size = new System.Drawing.Size(64, 14);
             this.lblPercentile.TabIndex = 8;
             this.lblPercentile.Text = "Percentile:";
             this.lblPercentile.Visible = false;
-                                                this.cboSeasonalMetric.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboSeasonalMetric
+            // 
+            this.cboSeasonalMetric.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboSeasonalMetric.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboSeasonalMetric.FormattingEnabled = true;
             this.cboSeasonalMetric.Location = new System.Drawing.Point(7, 159);
             this.cboSeasonalMetric.Name = "cboSeasonalMetric";
             this.cboSeasonalMetric.Size = new System.Drawing.Size(174, 22);
             this.cboSeasonalMetric.TabIndex = 7;
-                                                this.cboMetricStatistic.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboMetricStatistic
+            // 
+            this.cboMetricStatistic.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboMetricStatistic.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboMetricStatistic.FormattingEnabled = true;
             this.cboMetricStatistic.Location = new System.Drawing.Point(6, 118);
             this.cboMetricStatistic.Name = "cboMetricStatistic";
             this.cboMetricStatistic.Size = new System.Drawing.Size(175, 22);
             this.cboMetricStatistic.TabIndex = 6;
-                                                this.cboMetric.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboMetric
+            // 
+            this.cboMetric.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboMetric.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboMetric.FormattingEnabled = true;
             this.cboMetric.Location = new System.Drawing.Point(7, 76);
@@ -714,8 +933,11 @@ namespace BenMAP
             this.cboMetric.Size = new System.Drawing.Size(174, 22);
             this.cboMetric.TabIndex = 5;
             this.cboMetric.SelectedValueChanged += new System.EventHandler(this.cboMetric_SelectedValueChanged);
-                                                this.cboPollutant.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // cboPollutant
+            // 
+            this.cboPollutant.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.cboPollutant.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboPollutant.FormattingEnabled = true;
             this.cboPollutant.Location = new System.Drawing.Point(7, 35);
@@ -723,33 +945,48 @@ namespace BenMAP
             this.cboPollutant.Size = new System.Drawing.Size(174, 22);
             this.cboPollutant.TabIndex = 4;
             this.cboPollutant.SelectedValueChanged += new System.EventHandler(this.cboPollutant_SelectedValueChanged);
-                                                this.lblSeasonalMetric.AutoSize = true;
+            // 
+            // lblSeasonalMetric
+            // 
+            this.lblSeasonalMetric.AutoSize = true;
             this.lblSeasonalMetric.Location = new System.Drawing.Point(6, 145);
             this.lblSeasonalMetric.Name = "lblSeasonalMetric";
             this.lblSeasonalMetric.Size = new System.Drawing.Size(98, 14);
             this.lblSeasonalMetric.TabIndex = 3;
             this.lblSeasonalMetric.Text = "Seasonal Metric:";
-                                                this.lblMetricStatistic.AutoSize = true;
+            // 
+            // lblMetricStatistic
+            // 
+            this.lblMetricStatistic.AutoSize = true;
             this.lblMetricStatistic.Location = new System.Drawing.Point(6, 103);
             this.lblMetricStatistic.Name = "lblMetricStatistic";
             this.lblMetricStatistic.Size = new System.Drawing.Size(94, 14);
             this.lblMetricStatistic.TabIndex = 2;
             this.lblMetricStatistic.Text = "Annual Statistic:";
-                                                this.lblMetric.AutoSize = true;
+            // 
+            // lblMetric
+            // 
+            this.lblMetric.AutoSize = true;
             this.lblMetric.Location = new System.Drawing.Point(8, 62);
             this.lblMetric.Name = "lblMetric";
             this.lblMetric.Size = new System.Drawing.Size(44, 14);
             this.lblMetric.TabIndex = 1;
             this.lblMetric.Text = "Metric:";
-                                                this.lblPollutant.AutoSize = true;
+            // 
+            // lblPollutant
+            // 
+            this.lblPollutant.AutoSize = true;
             this.lblPollutant.Location = new System.Drawing.Point(6, 14);
             this.lblPollutant.Name = "lblPollutant";
             this.lblPollutant.Size = new System.Drawing.Size(60, 14);
             this.lblPollutant.TabIndex = 0;
             this.lblPollutant.Text = "Pollutant:";
-                                                this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // tabControl1
+            // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tbpFunction);
             this.tabControl1.Controls.Add(this.tbpBaselineFunction);
             this.tabControl1.Location = new System.Drawing.Point(10, 361);
@@ -757,7 +994,10 @@ namespace BenMAP
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.Size = new System.Drawing.Size(782, 245);
             this.tabControl1.TabIndex = 5;
-                                                this.tbpFunction.Controls.Add(this.lblFunction);
+            // 
+            // tbpFunction
+            // 
+            this.tbpFunction.Controls.Add(this.lblFunction);
             this.tbpFunction.Controls.Add(this.lstFuncAvailableSetupVariables);
             this.tbpFunction.Controls.Add(this.lstFuncAvailableVariables);
             this.tbpFunction.Controls.Add(this.txtFunction);
@@ -775,15 +1015,21 @@ namespace BenMAP
             this.tbpFunction.TabIndex = 0;
             this.tbpFunction.Text = "Function";
             this.tbpFunction.UseVisualStyleBackColor = true;
-                                                this.lblFunction.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            // 
+            // lblFunction
+            // 
+            this.lblFunction.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lblFunction.AutoSize = true;
             this.lblFunction.Location = new System.Drawing.Point(3, 126);
             this.lblFunction.Name = "lblFunction";
             this.lblFunction.Size = new System.Drawing.Size(56, 14);
             this.lblFunction.TabIndex = 11;
             this.lblFunction.Text = "Function:";
-                                                this.lstFuncAvailableSetupVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstFuncAvailableSetupVariables
+            // 
+            this.lstFuncAvailableSetupVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstFuncAvailableSetupVariables.FormattingEnabled = true;
             this.lstFuncAvailableSetupVariables.ItemHeight = 14;
             this.lstFuncAvailableSetupVariables.Location = new System.Drawing.Point(581, 21);
@@ -791,8 +1037,11 @@ namespace BenMAP
             this.lstFuncAvailableSetupVariables.Size = new System.Drawing.Size(187, 102);
             this.lstFuncAvailableSetupVariables.TabIndex = 10;
             this.lstFuncAvailableSetupVariables.DoubleClick += new System.EventHandler(this.lstFuncAvailableSetupVariables_DoubleClick);
-                                                this.lstFuncAvailableVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstFuncAvailableVariables
+            // 
+            this.lstFuncAvailableVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstFuncAvailableVariables.FormattingEnabled = true;
             this.lstFuncAvailableVariables.ItemHeight = 14;
             this.lstFuncAvailableVariables.Location = new System.Drawing.Point(430, 21);
@@ -800,17 +1049,23 @@ namespace BenMAP
             this.lstFuncAvailableVariables.Size = new System.Drawing.Size(145, 102);
             this.lstFuncAvailableVariables.TabIndex = 9;
             this.lstFuncAvailableVariables.DoubleClick += new System.EventHandler(this.lstFuncAvailableVariables_DoubleClick);
-                                                this.txtFunction.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtFunction
+            // 
+            this.txtFunction.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtFunction.Location = new System.Drawing.Point(6, 143);
             this.txtFunction.Multiline = true;
             this.txtFunction.Name = "txtFunction";
             this.txtFunction.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.txtFunction.Size = new System.Drawing.Size(762, 64);
             this.txtFunction.TabIndex = 12;
-                                                this.lstCommonUsedFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstCommonUsedFunctions
+            // 
+            this.lstCommonUsedFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstCommonUsedFunctions.FormattingEnabled = true;
             this.lstCommonUsedFunctions.HorizontalScrollbar = true;
             this.lstCommonUsedFunctions.ItemHeight = 14;
@@ -820,8 +1075,11 @@ namespace BenMAP
             this.lstCommonUsedFunctions.Size = new System.Drawing.Size(267, 102);
             this.lstCommonUsedFunctions.TabIndex = 8;
             this.lstCommonUsedFunctions.DoubleClick += new System.EventHandler(this.lstFuncAllAvailableFunctions_DoubleClick);
-                                                this.lstFuncAvailableFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstFuncAvailableFunctions
+            // 
+            this.lstFuncAvailableFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstFuncAvailableFunctions.FormattingEnabled = true;
             this.lstFuncAvailableFunctions.ItemHeight = 14;
             this.lstFuncAvailableFunctions.Location = new System.Drawing.Point(279, 21);
@@ -829,39 +1087,57 @@ namespace BenMAP
             this.lstFuncAvailableFunctions.Size = new System.Drawing.Size(145, 102);
             this.lstFuncAvailableFunctions.TabIndex = 6;
             this.lstFuncAvailableFunctions.DoubleClick += new System.EventHandler(this.lstFuncAvailableFunctions_DoubleClick);
-                                                this.lblExistingFunctions.AutoSize = true;
+            // 
+            // lblExistingFunctions
+            // 
+            this.lblExistingFunctions.AutoSize = true;
             this.lblExistingFunctions.Location = new System.Drawing.Point(6, 3);
             this.lblExistingFunctions.Name = "lblExistingFunctions";
             this.lblExistingFunctions.Size = new System.Drawing.Size(193, 14);
             this.lblExistingFunctions.TabIndex = 5;
             this.lblExistingFunctions.Text = "Commonly Used Functional Forms:";
-                                                this.label5.AutoSize = true;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(477, 44);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(0, 14);
             this.label5.TabIndex = 3;
-                                                this.lblComposeSetupVariables.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lblComposeSetupVariables
+            // 
+            this.lblComposeSetupVariables.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblComposeSetupVariables.AutoSize = true;
             this.lblComposeSetupVariables.Location = new System.Drawing.Point(580, 3);
             this.lblComposeSetupVariables.Name = "lblComposeSetupVariables";
             this.lblComposeSetupVariables.Size = new System.Drawing.Size(178, 14);
             this.lblComposeSetupVariables.TabIndex = 2;
             this.lblComposeSetupVariables.Text = "Population Variables(optional):";
-                                                this.lblComposeVariables.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lblComposeVariables
+            // 
+            this.lblComposeVariables.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lblComposeVariables.AutoSize = true;
             this.lblComposeVariables.Location = new System.Drawing.Point(428, 3);
             this.lblComposeVariables.Name = "lblComposeVariables";
             this.lblComposeVariables.Size = new System.Drawing.Size(117, 14);
             this.lblComposeVariables.TabIndex = 1;
             this.lblComposeVariables.Text = "Available Variables:";
-                                                this.lbl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lbl
+            // 
+            this.lbl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.lbl.AutoSize = true;
             this.lbl.Location = new System.Drawing.Point(277, 3);
             this.lbl.Name = "lbl";
             this.lbl.Size = new System.Drawing.Size(64, 14);
             this.lbl.TabIndex = 0;
             this.lbl.Text = "Operators:";
-                                                this.tbpBaselineFunction.Controls.Add(this.txtBaselineIncidenceFunction);
+            // 
+            // tbpBaselineFunction
+            // 
+            this.tbpBaselineFunction.Controls.Add(this.txtBaselineIncidenceFunction);
             this.tbpBaselineFunction.Controls.Add(this.label8);
             this.tbpBaselineFunction.Controls.Add(this.label7);
             this.tbpBaselineFunction.Controls.Add(this.label6);
@@ -878,50 +1154,71 @@ namespace BenMAP
             this.tbpBaselineFunction.TabIndex = 1;
             this.tbpBaselineFunction.Text = "Baseline Incidence Function";
             this.tbpBaselineFunction.UseVisualStyleBackColor = true;
-                                                this.txtBaselineIncidenceFunction.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // txtBaselineIncidenceFunction
+            // 
+            this.txtBaselineIncidenceFunction.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBaselineIncidenceFunction.Location = new System.Drawing.Point(6, 143);
             this.txtBaselineIncidenceFunction.Multiline = true;
             this.txtBaselineIncidenceFunction.Name = "txtBaselineIncidenceFunction";
             this.txtBaselineIncidenceFunction.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.txtBaselineIncidenceFunction.Size = new System.Drawing.Size(762, 64);
             this.txtBaselineIncidenceFunction.TabIndex = 11;
-                                                this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            // 
+            // label8
+            // 
+            this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label8.AutoSize = true;
             this.label8.Location = new System.Drawing.Point(3, 126);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(56, 14);
             this.label8.TabIndex = 10;
             this.label8.Text = "Function:";
-                                                this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // label7
+            // 
+            this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(579, 3);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(178, 14);
             this.label7.TabIndex = 9;
             this.label7.Text = "Population Variables(optional):";
-                                                this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label6.AutoSize = true;
             this.label6.Location = new System.Drawing.Point(428, 3);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(117, 14);
             this.label6.TabIndex = 8;
             this.label6.Text = "Available Variables:";
-                                                this.label4.AutoSize = true;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(6, 3);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(193, 14);
             this.label4.TabIndex = 7;
             this.label4.Text = "Commonly Used Functional Forms:";
-                                                this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(277, 3);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(64, 14);
             this.label2.TabIndex = 5;
             this.label2.Text = "Operators:";
-                                                this.lstBaselineAvailableSetupVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstBaselineAvailableSetupVariables
+            // 
+            this.lstBaselineAvailableSetupVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstBaselineAvailableSetupVariables.FormattingEnabled = true;
             this.lstBaselineAvailableSetupVariables.ItemHeight = 14;
             this.lstBaselineAvailableSetupVariables.Location = new System.Drawing.Point(581, 21);
@@ -929,8 +1226,11 @@ namespace BenMAP
             this.lstBaselineAvailableSetupVariables.Size = new System.Drawing.Size(187, 102);
             this.lstBaselineAvailableSetupVariables.TabIndex = 4;
             this.lstBaselineAvailableSetupVariables.DoubleClick += new System.EventHandler(this.lstBaselineAvailableSetupVariables_DoubleClick);
-                                                this.lstBaselineAvailableVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstBaselineAvailableVariables
+            // 
+            this.lstBaselineAvailableVariables.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstBaselineAvailableVariables.FormattingEnabled = true;
             this.lstBaselineAvailableVariables.ItemHeight = 14;
             this.lstBaselineAvailableVariables.Location = new System.Drawing.Point(430, 21);
@@ -938,9 +1238,12 @@ namespace BenMAP
             this.lstBaselineAvailableVariables.Size = new System.Drawing.Size(145, 102);
             this.lstBaselineAvailableVariables.TabIndex = 3;
             this.lstBaselineAvailableVariables.DoubleClick += new System.EventHandler(this.lstBaselineAvailableVariables_DoubleClick);
-                                                this.lstBaselineCommonUsedFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Left)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstBaselineCommonUsedFunctions
+            // 
+            this.lstBaselineCommonUsedFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstBaselineCommonUsedFunctions.FormattingEnabled = true;
             this.lstBaselineCommonUsedFunctions.HorizontalScrollbar = true;
             this.lstBaselineCommonUsedFunctions.ItemHeight = 14;
@@ -950,8 +1253,11 @@ namespace BenMAP
             this.lstBaselineCommonUsedFunctions.Size = new System.Drawing.Size(267, 102);
             this.lstBaselineCommonUsedFunctions.TabIndex = 2;
             this.lstBaselineCommonUsedFunctions.DoubleClick += new System.EventHandler(this.lstBaselineAllAvailableFunctions_DoubleClick);
-                                                this.lstBaselineAvailableFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-                        | System.Windows.Forms.AnchorStyles.Right)));
+            // 
+            // lstBaselineAvailableFunctions
+            // 
+            this.lstBaselineAvailableFunctions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.lstBaselineAvailableFunctions.FormattingEnabled = true;
             this.lstBaselineAvailableFunctions.ItemHeight = 14;
             this.lstBaselineAvailableFunctions.Location = new System.Drawing.Point(279, 21);
@@ -959,7 +1265,10 @@ namespace BenMAP
             this.lstBaselineAvailableFunctions.Size = new System.Drawing.Size(145, 102);
             this.lstBaselineAvailableFunctions.TabIndex = 0;
             this.lstBaselineAvailableFunctions.DoubleClick += new System.EventHandler(this.lstBaselineAvailableFunctions_DoubleClick);
-                                                this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 14F);
+            // 
+            // HealthImpactFunctionOfUser_defined
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 14F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
             this.ClientSize = new System.Drawing.Size(803, 658);

--- a/BenMAP/ManageSetup/LoadPopulationDataSet.cs
+++ b/BenMAP/ManageSetup/LoadPopulationDataSet.cs
@@ -94,6 +94,7 @@ namespace BenMAP
 
         private void btnView_Click(object sender, EventArgs e)
         {
+            int selectedIndex = cboConfiguration.SelectedIndex;
             FireBirdHelperBase fb = new ESILFireBirdHelper();
             try
             {
@@ -102,6 +103,15 @@ namespace BenMAP
                 frm._configurationName = _popConfig;
                 frm._configurationID = _popConfigID;
                 DialogResult rtn = frm.ShowDialog();
+                if (rtn == DialogResult.OK)
+                {
+                    string commandText = "select PopulationConfigurationName from PopulationConfigurations";
+                    DataSet dt = fb.ExecuteDataset(CommonClass.Connection, CommandType.Text, commandText);
+                    cboConfiguration.DataSource = dt.Tables[0];
+                    cboConfiguration.DisplayMember = "POPULATIONCONFIGURATIONNAME";
+                    cboConfiguration.SelectedIndex = selectedIndex;
+                    cboConfiguration.Refresh();
+                }
             }
             catch (Exception ex)
             {
@@ -146,6 +156,7 @@ namespace BenMAP
                     cboConfiguration.DataSource = dt.Tables[0];
                     cboConfiguration.DisplayMember = "POPULATIONCONFIGURATIONNAME";
                     cboConfiguration.SelectedIndex = -1;
+                    cboConfiguration.Refresh();
                 }
             }
             catch (Exception ex)

--- a/BenMAP/ManageSetup/ValuationFunctionDataSetDefinition.cs
+++ b/BenMAP/ManageSetup/ValuationFunctionDataSetDefinition.cs
@@ -462,7 +462,7 @@ namespace BenMAP
                             dicValuationFunction.Add(_dt.Rows[row][6].ToString(), FunctionalFormID);
                             //dicValuationFunction.Add(dtForLoading.Rows[row][6].ToString(), FunctionalFormID);
                         }
-                        
+
                         //commandText = string.Format("insert into ValuationFunctions values({0},{1},{2},{3},'{4}','{5}',{6},{7},{8},{9},'{10}','{11}',{12},{13},{14},'{15}',{16},'{17}',{18},'{19}', {20})",
                         //                            valuationFunctionID, VValuationFunctionDataSetID, EndpointGroupID, EndpointID, _dt.Rows[row][2].ToString().Replace("'", "''"), _dt.Rows[row][3].ToString().Replace("'", "''"),
                         //                                _dt.Rows[row][4], _dt.Rows[row][5], FunctionalFormID, _dt.Rows[row][7], _dt.Rows[row][8].ToString().Replace("'", "''"), _dt.Rows[row][9].ToString().Replace("'", "''"),
@@ -470,6 +470,22 @@ namespace BenMAP
                         //                                _dt.Rows[row][16], _dt.Rows[row][17].ToString().Replace("'", "''"), _metadataObj.MetadataEntryId);
                         // 2015 09 23 - BENMAP-357 replaced metadata objext in insert
                         /// // removed metadata object from insert -
+                        /// 
+                        // 2017 05 29 IEc BENMAP-225 Address issue with adding entries to newly created datasets (e.g. HIF, Valuation, ...)
+                        // Issue caused by _metadataObj not set to an instance while manually enter data instead of importing from a file.
+                        // Please note that [CRFunctions].[METADATAID] links to [METADATAINFORMATION].[METADATAENTRYID].
+                        if (_metadataObj == null)
+                        {
+                            _metadataObj = new MetadataClassObj();
+                            _metadataObj.SetupId = CommonClass.ManageSetup.SetupID;
+                            _metadataObj.DatasetId = valuationFunctionDataSetID;
+                            _metadataObj.DatasetTypeId = VALUATIONDATASETTYPEID; //according to BENMAP-353's notes, datasettypeid for Valuation Functions has been hardcoded to 7.
+                            _metadataObj.ImportDate = DateTime.Today.ToString("d");
+                            _metadataObj.Description = "Health impact functions manually entered through Health Impact Function Definition form.";
+
+                            commandText = "select max(METADATAENTRYID) from METADATAINFORMATION";
+                            _metadataObj.MetadataEntryId = Convert.ToInt32(fb.ExecuteScalar(CommonClass.Connection, CommandType.Text, commandText)) + 1;
+                        }
                         commandText = string.Format("insert into ValuationFunctions(VALUATIONFUNCTIONID, VALUATIONFUNCTIONDATASETID, ENDPOINTGROUPID, ENDPOINTID, "
                                     + "QUALIFIER, REFERENCE, STARTAGE, ENDAGE, FUNCTIONALFORMID, A, NAMEA, DISTA, P1A, P2A, B, NAMEB, C, NAMEC, D, NAMED, METADATAID) "
                                     + "values({0},{1},{2},{3},'{4}','{5}',{6},{7},{8},{9},'{10}','{11}',{12},{13},{14},'{15}',{16},'{17}',{18},'{19}', {20})",


### PR DESCRIPTION
Fix the issue that when creating a new Health Impact Function dataset or Variable Function Dataset, the first function will not be saved if it is manually entered. Also fix the issue that when creating a new population configuration, users have to close the window and reopen it to see the newly added population configuration. 