### PR TITLE
Make Help > Quick Start Guide link to the correct web page.

### DIFF
--- a/BenMAP/Main.cs
+++ b/BenMAP/Main.cs
@@ -409,7 +409,7 @@ namespace BenMAP
         {
             try
             {
-                System.Diagnostics.Process.Start("http://www.epa.gov/air/benmap/ce.html");
+                System.Diagnostics.Process.Start("https://www.epa.gov/benmap/benmap-ce-training-materials");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The Help > Quick Start Guide option in BenMAP v1.3.5.12 was bringing to this web page which no longer exists. It's now corrected to https://www.epa.gov/benmap/benmap-ce-training-materials