### PR TITLE
BENMAP-230 Command Line Overrides Income Growth Year

### DIFF
--- a/BenMAP/BatchCommonClass.cs
+++ b/BenMAP/BatchCommonClass.cs
@@ -529,7 +529,9 @@ namespace BenMAP
                                 valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.ValuationAggregation = getGridFromName(batchAPV.ValuationAggregation);
                             }
                             if (batchAPV.DollarYear != null && batchAPV.DollarYear != "")
-                                valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.IncomeGrowthYear = Convert.ToInt32(batchAPV.DollarYear);
+                                //valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.IncomeGrowthYear = Convert.ToInt32(batchAPV.DollarYear);
+                                valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.CurrencyYear = Convert.ToInt32(batchAPV.DollarYear);
+                                //Income growth year is different from currency year. Income growth year should remain what is specified in APV (*.apvx) file. 
                             if (batchAPV.RandomSeed != -1)
                                 valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.RandomSeed = batchAPV.RandomSeed.ToString();
 


### PR DESCRIPTION
When users add -DollarYear parameter, instead of CurrencyYear (inflation year), the value of this parameter overrides Income Growth Year in APV file. Correct this so that only dollar year (CurrencyYear / inflation year) is overridden by optional parameter -DollarYear.