### PR TITLE
Update for BenMAP-381

### DIFF
--- a/BenMAP/DataSource/OpenExistingAQG.cs
+++ b/BenMAP/DataSource/OpenExistingAQG.cs
@@ -211,11 +211,12 @@ namespace BenMAP
 					else
 						return;
 				}
-				int pathIdx = sfd.FileName.LastIndexOf("\\");
-				sfd.InitialDirectory = saveBasePath.Substring(0, pathIdx);
-				sfd.FileName = "";
+
 				if (!txtControl.Text.ToLower().EndsWith("aqgx"))
 				{
+					int pathIdx = sfd.FileName.LastIndexOf("\\");
+					sfd.InitialDirectory = saveBasePath.Substring(0, pathIdx);
+					sfd.FileName = "";
 					sfd.Title = "Save the control Grid.";
 					if (sfd.ShowDialog() == DialogResult.OK)
 						saveControlPath = sfd.FileName;


### PR DESCRIPTION
--When a user opens non-AQGX files in the "Open Existing AQ Data" section, they are prompted for a location to save the resulting file.
--Previously, the code to remember their selection for saving the base file was in the wrong spot & caused an error when opening AQGX files. Now corrected.