### PR TITLE
Fixes for BenMAP 400 (GIS Export)

### DIFF
--- a/BenMAP/DataLayerExport/DataLayerExportDialog.cs
+++ b/BenMAP/DataLayerExport/DataLayerExportDialog.cs
@@ -107,8 +107,10 @@ namespace BenMAP.DataLayerExport
 					var findLayer = _dictAllLayers.Where(x => x.Key.Item2 == layerInfo);
 
 					if (findLayer.Count() == 0)
+					{
 						_dictAllLayers.Add(new Tuple<string, string, int>("Air Quality", layerInfo, aqCount), new Tuple<int, CheckState>(layerCount, CheckState.Unchecked));
-					aqCount += 1;
+						aqCount += 1;
+					}
 				}
 				else if (layerType == "Health Impacts")
 				{
@@ -227,7 +229,18 @@ namespace BenMAP.DataLayerExport
 					return;
 				}
 
-				var fileName = Regex.Replace(layerType + "-" + layerExport.LegendText, "[;\\/:*?\"<>|&',]", "");
+				string fileName = String.Empty;
+				if (layerType.Equals("Air Quality"))
+				{
+					int pollIdx = entry.Key.Item2.IndexOf(":");
+					string currPollutant = entry.Key.Item2.Substring(0, pollIdx);
+					fileName = Regex.Replace(layerType + "-" + currPollutant + "-" + layerExport.LegendText, "[;\\/:*?\"<>|&',]", "");
+				}
+				else
+				{
+					fileName = Regex.Replace(layerType + "-" + layerExport.LegendText, "[;\\/:*?\"<>|&',]", "");
+				}
+
 				layers.Add(layerExport);
 				columns.Add(colExport);
 				fileNames.Add(fileName);

--- a/BenMAP/DataLayerExport/DataLayerExporter.cs
+++ b/BenMAP/DataLayerExport/DataLayerExporter.cs
@@ -218,7 +218,7 @@ namespace BenMAP.DataLayerExport
 				_windowShown = true;
 				window.ShowDialog(_windowOwner);
 				_windowShown = false;
-				MessageBox.Show("Export Complete");
+				//MessageBox.Show("Export Complete");
 			}
 		}
 


### PR DESCRIPTION
Allows export of AQ grids from multiple pollutants
--Now tracks AQ layers correctly and includes the pollutant in the file name to prevent overwriting across pollutants