### PR TITLE
Update (Pollutant Definition, Global and Seasonal Metrics, Model Data)

### DIFF
--- a/BenMAP/ManageSetup/ManageSeasonalMetrics.Designer.cs
+++ b/BenMAP/ManageSetup/ManageSeasonalMetrics.Designer.cs
@@ -168,6 +168,7 @@ namespace BenMAP
 			this.dtpEndTime.ShowUpDown = true;
 			this.dtpEndTime.Size = new System.Drawing.Size(101, 22);
 			this.dtpEndTime.TabIndex = 3;
+			this.dtpEndTime.ValueChanged += new System.EventHandler(this.dtpEndTime_ValueChanged);
 			this.dtpEndTime.Leave += new System.EventHandler(this.dtpEndTime_Leave);
 			// 
 			// dtpStartTime
@@ -179,6 +180,7 @@ namespace BenMAP
 			this.dtpStartTime.ShowUpDown = true;
 			this.dtpStartTime.Size = new System.Drawing.Size(101, 22);
 			this.dtpStartTime.TabIndex = 1;
+			this.dtpStartTime.ValueChanged += new System.EventHandler(this.dtpStartTime_ValueChanged);
 			this.dtpStartTime.Leave += new System.EventHandler(this.dtpStartTime_Leave);
 			// 
 			// tabMetricFunction

--- a/BenMAP/ManageSetup/PollutantDefinition.cs
+++ b/BenMAP/ManageSetup/PollutantDefinition.cs
@@ -885,7 +885,9 @@ namespace BenMAP
 				}
 				updateBenMAPPollutant(_benMAPPollutant);
 				if (PollutantExist || customFunctionInvalid) return;
-				ManageSeasonalMetrics frm = new ManageSeasonalMetrics(_lstSeasonalMetric, _metric, _isAddPollutant);
+				if (_dicSeasons.Count == 0) return;
+
+				ManageSeasonalMetrics frm = new ManageSeasonalMetrics(_lstSeasonalMetric, _metric, _isAddPollutant, _dicSeasons);
 				frm.ShowDialog();
 				{
 					if (ManageSeasonalMetrics.LstSMetrics.Count != 0)


### PR DESCRIPTION
-Addresses the calculation of metrics for global seasons and seasonal metrics that are some subset of the full year
-Handles the calculation and replacement of missing data within the global season correctly
-Draw on the appropriate AQ data based on the selection of HIF
-Restricts the dates of seasonal metrics to lie within the global season
-Adds comments to help trace the logic of the AQ step