### PR TITLE
Fix an issue that the "Configuration Results Report" window will hand…

### DIFF
--- a/BenMAP/APV/APVCommonClass.cs
+++ b/BenMAP/APV/APVCommonClass.cs
@@ -370,6 +370,11 @@ namespace BenMAP.APVX
 						}
 					}
 					ConvertOldPoolingTree(valuationMethodPoolingAndAggregation);
+					if(valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance != null)
+					{
+						//population was always calculated before the calculation method updates in 2020.
+						valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.CalculatePooledPopulationYN = true;
+					}
 				}
 
 

--- a/BenMAP/ConfigurationResulesReport.cs
+++ b/BenMAP/ConfigurationResulesReport.cs
@@ -78,18 +78,25 @@ namespace BenMAP
 					lstResult.Add(new FieldCheck() { FieldName = "Mean", isChecked = true });
 					lstResult.Add(new FieldCheck() { FieldName = "Standard Deviation", isChecked = true });
 					lstResult.Add(new FieldCheck() { FieldName = "Variance", isChecked = true });
-					if (CommonClass.IncidencePoolingAndAggregationAdvance != null && CommonClass.IncidencePoolingAndAggregationAdvance.CalculatePooledPopulationYN)
+					if (isPooledIncidence)
+					{
+						if (CommonClass.IncidencePoolingAndAggregationAdvance != null && CommonClass.IncidencePoolingAndAggregationAdvance.CalculatePooledPopulationYN)
+						{
+							lstResult.Add(new FieldCheck() { FieldName = "Population", isChecked = true });
+							lstResult.Add(new FieldCheck() { FieldName = "Baseline", isChecked = true });
+							lstResult.Add(new FieldCheck() { FieldName = "Percent of Baseline", isChecked = true });
+						}
+					}
+					else
 					{
 						lstResult.Add(new FieldCheck() { FieldName = "Population", isChecked = true });
 						lstResult.Add(new FieldCheck() { FieldName = "Baseline", isChecked = true });
 						lstResult.Add(new FieldCheck() { FieldName = "Percent of Baseline", isChecked = true });
-						if (!isPooledIncidence)
-						{
-							lstResult.Add(new FieldCheck() { FieldName = "Population Weighted Delta", isChecked = false });
-							lstResult.Add(new FieldCheck() { FieldName = "Population Weighted Base", isChecked = false });
-							lstResult.Add(new FieldCheck() { FieldName = "Population Weighted Control", isChecked = false });
-						}
+						lstResult.Add(new FieldCheck() { FieldName = "Population Weighted Delta", isChecked = false });
+						lstResult.Add(new FieldCheck() { FieldName = "Population Weighted Base", isChecked = false });
+						lstResult.Add(new FieldCheck() { FieldName = "Population Weighted Control", isChecked = false });
 					}
+						
 
 
 					lstResult.Add(new FieldCheck() { FieldName = "Percentiles", isChecked = true });


### PR DESCRIPTION
Fix an issue in ConfigurationResulesReport.cs so that the "Configuration Results Report" window will handle population, baseline and percent baseline fields differently between HIF results and Pooled incidence results.