### PR TITLE
Update (Seasonal Metric Seasons)

### DIFF
--- a/BenMAP/DataSource/DataSourceCommonClass.cs
+++ b/BenMAP/DataSource/DataSourceCommonClass.cs
@@ -1343,9 +1343,12 @@ namespace BenMAP
 							{
 								mrAttribute.Values.Add(seasonalmetric.SeasonalMetricName, mAttribute.Values.First());
 							}
-							else if (mAttribute.Values.Count == mAttribute.SeasonalMetric.Seasons.Count)
+							else if (mAttribute.SeasonalMetric != null) //confirm that there is a seasonal metric before accessing the count of seasons
 							{
-								mrAttribute.Values.Add(seasonalmetric.SeasonalMetricName, mAttribute.Values.Average());
+								if (mAttribute.Values.Count == mAttribute.SeasonalMetric.Seasons.Count)
+								{
+									mrAttribute.Values.Add(seasonalmetric.SeasonalMetricName, mAttribute.Values.Average());
+								}
 							}
 
 						}

--- a/BenMAP/ManageSetup/PollutantDefinition.cs
+++ b/BenMAP/ManageSetup/PollutantDefinition.cs
@@ -845,6 +845,7 @@ namespace BenMAP
 				}
 				DefineSeasons frm = new DefineSeasons(_isAddPollutant);
 				frm._pollutantID = _pollutantID;
+				frm._lstSeasonalMetric = _lstAllSeasonalMetric;		//pass seasonal metric information to the global pollutant window
 				frm.dicSave = _dicSeasons;
 				DialogResult rtn = frm.ShowDialog();
 				{


### PR DESCRIPTION
-Currently, within the seasonal metric season window, BenMAP checks to make sure those seasons fall within the global pollutant season.
-This update ensures the same check within the global pollutant season window. Namely that seasonal metric seasons don't lie outside the global pollutant season after a potential edit to the start/end of the global season.