### PR TITLE
Add conditional statements to handle some silenced errors. 

### DIFF
--- a/BenMAP/APV/IncidencePoolingandAggregation.cs
+++ b/BenMAP/APV/IncidencePoolingandAggregation.cs
@@ -334,7 +334,7 @@ namespace BenMAP
 					{
 						AllSelectCRFunction dir = (AllSelectCRFunction)x;
 						IncidencePoolingAndAggregation ip = CommonClass.lstIncidencePoolingAndAggregation.Where(p => p.PoolingName == tabControlSelected.TabPages[tabControlSelected.SelectedIndex].Text).First();
-						if (ip.lstAllSelectCRFuntion.Where(p => p.PID == dir.ID).Count() > 0)
+						if (ip.lstAllSelectCRFuntion != null &&  ip.lstAllSelectCRFuntion.Where(p => p.PID == dir.ID).Count() > 0)
 							return true;
 						else
 							return false;

--- a/BenMAP/APV/SelectValuationMethods.cs
+++ b/BenMAP/APV/SelectValuationMethods.cs
@@ -1653,7 +1653,7 @@ CommonClass.ValuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationA
 			addColumnsToTree(vb.lstValuationColumns);
 			//Show weight column if user defined weight is selected
 			int widthWeight = 0;
-			if (vb.LstAllSelectValuationMethod.Select(p => p.PoolingMethod).Contains("User Defined Weights"))
+			if (vb.LstAllSelectValuationMethod!=null && vb.LstAllSelectValuationMethod.Select(p => p.PoolingMethod).Contains("User Defined Weights"))
 			{
 				widthWeight = 60;
 			}

--- a/BenMAP/BenMap.cs
+++ b/BenMAP/BenMap.cs
@@ -1958,7 +1958,11 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 					string s = "";
 					try
 					{
-						s = (bcg.Base as ModelDataLine).DatabaseFilePath.Substring((bcg.Base as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						if(bcg.Base is ModelDataLine)
+						{
+							s = (bcg.Base as ModelDataLine).DatabaseFilePath.Substring((bcg.Base as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						}
+						
 
 					}
 					catch
@@ -1978,7 +1982,11 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 					string s = "";
 					try
 					{
-						s = (bcg.Control as ModelDataLine).DatabaseFilePath.Substring((bcg.Control as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						if (bcg.Base is ModelDataLine)
+						{
+							s = (bcg.Control as ModelDataLine).DatabaseFilePath.Substring((bcg.Control as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						}
+							
 
 					}
 					catch
@@ -4291,8 +4299,10 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 						//ModelDataLine mdl = (BenMAPLine)bcg.Base;
 						//String test = mdl.DatabaseFilePath;
 						//bcg.Base.da
-						s = (bcg.Base as ModelDataLine).DatabaseFilePath.Substring((bcg.Base as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
-
+						if(bcg.Base is ModelDataLine)
+						{
+							s = (bcg.Base as ModelDataLine).DatabaseFilePath.Substring((bcg.Base as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						}
 					}
 					catch (Exception e)
 					{
@@ -4313,7 +4323,11 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 					string s = "";
 					try
 					{
-						s = (bcg.Control as ModelDataLine).DatabaseFilePath.Substring((bcg.Control as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						if(bcg.Control is ModelDataLine)
+						{
+							s = (bcg.Control as ModelDataLine).DatabaseFilePath.Substring((bcg.Control as ModelDataLine).DatabaseFilePath.LastIndexOf(@"\") + 1);
+						}
+						
 
 					}
 					catch
@@ -7509,7 +7523,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 
 					foreach (KeyValuePair<AllSelectValuationMethod, string> keyValue in tlvAPVResult.SelectedObjects)
 					{
-						if (keyValue.Key.BenMAPValuationFunction.ID == lstallSelectValuationMethodAndValue.First().AllSelectValuationMethod.BenMAPValuationFunction.ID)
+						if (keyValue.Key.BenMAPValuationFunction != null && keyValue.Key.BenMAPValuationFunction.ID == lstallSelectValuationMethodAndValue.First().AllSelectValuationMethod.BenMAPValuationFunction.ID)
 						{
 							poolingWindow = keyValue.Value;
 						}

--- a/BenMAP/Configuration/HealthImpactFunctions.cs
+++ b/BenMAP/Configuration/HealthImpactFunctions.cs
@@ -302,7 +302,10 @@ namespace BenMAP
 									{
 										if (dr["IncidenceDataSetName"].ToString().Contains("(") && dr["IncidenceDataSetName"].ToString().Contains(")"))
 										{
-											drNextYear = int.Parse(dr["IncidenceDataSetName"].ToString().Substring(dr["IncidenceDataSetName"].ToString().IndexOf("(") + 1, dr["IncidenceDataSetName"].ToString().IndexOf(")") - dr["IncidenceDataSetName"].ToString().IndexOf("(") - 1));
+											//drNextYear = int.Parse(dr["IncidenceDataSetName"].ToString().Substring(dr["IncidenceDataSetName"].ToString().IndexOf("(") + 1, dr["IncidenceDataSetName"].ToString().IndexOf(")") - dr["IncidenceDataSetName"].ToString().IndexOf("(") - 1));
+											string tmpStr = dr["IncidenceDataSetName"].ToString().Substring(dr["IncidenceDataSetName"].ToString().IndexOf("(") + 1, dr["IncidenceDataSetName"].ToString().IndexOf(")") - dr["IncidenceDataSetName"].ToString().IndexOf("(") - 1);
+											int.TryParse(tmpStr, out drNextYear);
+
 											if (drNextYear > 0 && Math.Abs(drNextYear - CommonClass.BenMAPPopulation.Year) < Math.Abs(drYear - CommonClass.BenMAPPopulation.Year))
 											{
 												drYear = drNextYear;


### PR DESCRIPTION
Handle some silenced errors. Fix a bug which prevents HIF window automatically selected the incidence dataset with closest year when the incidence dataset name contains parentheses but didn't put standard year format in in (For example, "Race-Stratified Mortality Incidence (2007-16)").