### PR TITLE
Sprint 21-4 Fixes

### DIFF
--- a/BenMAP/DataSource/DataSourceCommonClass.cs
+++ b/BenMAP/DataSource/DataSourceCommonClass.cs
@@ -2831,10 +2831,14 @@ Math.Cos(Y0 / 180 * Math.PI) * Math.Cos(Y1 / 180 * Math.PI) * Math.Pow(Math.Sin(
 						}
 						else
 						{
-							//If day 120 to day 153 has more than half of the days (>16 days) with values = float.MinValue, don't add this monitor value record to lstMonitorValues
-							if (mv.Values.GetRange(120, 272 - 120 + 1).Where(p => p != float.MinValue).Count() < mv.Values.GetRange(120, 272 - 120 + 1).Count / 2)
+							//BENMAP 522: Added logic to prevent indexing of values when the user provides a single value.
+							if (mv.Values.Count() > 364)
 							{
-								return;
+								//If day 120 to day 153 has more than half of the days (>16 days) with values = float.MinValue, don't add this monitor value record to lstMonitorValues
+								if (mv.Values.GetRange(120, 272 - 120 + 1).Where(p => p != float.MinValue).Count() < mv.Values.GetRange(120, 272 - 120 + 1).Count / 2)
+								{
+									return;
+								}
 							}
 
 						}

--- a/BenMAP/ManageSetup/LoadInflationDataSet.cs
+++ b/BenMAP/ManageSetup/LoadInflationDataSet.cs
@@ -239,10 +239,11 @@ namespace BenMAP
 					//LoadDatabase();
 					btnOK.Enabled = true;
 				}
-				else
-				{
-					btnOK.Enabled = false;
-				}
+				//BENMAP 518: Commented out the else statement to follow the practice in place for other validation. This prevents the greying out of the OK button if the user succesfully validates when validation is not forced.
+				//else
+				//{
+				//	btnOK.Enabled = false;
+				//}
 			}
 		}
 


### PR DESCRIPTION
BenMAP 518: Address a bug that incorrectly disables the "OK" button in the valuation dataset import window under a specific scenario.
BenMAP 522: Address a bug that does not allow users to import a single value for monitor data.