### PR TITLE
BENMAP-539 Retain advanced selection of option 2 (filtered incidence)…

### DIFF
--- a/BenMAP/APV/APVCommonClass.cs
+++ b/BenMAP/APV/APVCommonClass.cs
@@ -39,6 +39,7 @@ namespace BenMAP.APVX
 				copy.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
 				copy.lstLog = CommonClass.BaseControlCRSelectFunctionCalculateValue.lstLog;
 				copy.lstCRSelectFunctionCalculateValue = new List<CRSelectFunctionCalculateValue>();
+				copy.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 				List<float> lstd = new List<float>();
 				foreach (CRSelectFunctionCalculateValue crr in BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue)
 				{

--- a/BenMAP/APV/OpenExistingAPVConfiguration.cs
+++ b/BenMAP/APV/OpenExistingAPVConfiguration.cs
@@ -109,6 +109,10 @@ namespace BenMAP
 
 				}
 
+				//YY: 539
+				CommonClass.incidenceAvgSelected = valuationMethodPoolingAndAggregation.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected;
+				Configuration.ConfigurationCommonClass.incidenceAvgSelected = valuationMethodPoolingAndAggregation.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected;
+
 				CommonClass.BaseControlCRSelectFunctionCalculateValue = null;
 
 				if (CommonClass.LstUpdateCRFunction != null)
@@ -151,6 +155,10 @@ namespace BenMAP
 							return;
 						}
 					}
+
+					//YY: 539
+					CommonClass.incidenceAvgSelected = valuationMethodPoolingAndAggregation.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected;
+					Configuration.ConfigurationCommonClass.incidenceAvgSelected = valuationMethodPoolingAndAggregation.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected;
 
 					CommonClass.BaseControlCRSelectFunctionCalculateValue = null;
 

--- a/BenMAP/AuditTrailReportCommonClass.cs
+++ b/BenMAP/AuditTrailReportCommonClass.cs
@@ -359,7 +359,7 @@ namespace BenMAP
 				advNode.Nodes.Add("Threshold: " + baseControlCRSelectFunction.CRThreshold);
 
 				String incidenceTxt = "";
-				if (Configuration.ConfigurationCommonClass.indidenceAvgSelected == Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll)
+				if (Configuration.ConfigurationCommonClass.incidenceAvgSelected == Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll)
 				{
 					incidenceTxt = "All";
 				}
@@ -481,7 +481,7 @@ namespace BenMAP
 				advNode.Nodes.Add("Threshold: " + baseControlCRSelectFunctionCalculateValue.CRThreshold);
 
 				String incidenceTxt = "";
-				if (Configuration.ConfigurationCommonClass.indidenceAvgSelected == Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll)
+				if (Configuration.ConfigurationCommonClass.incidenceAvgSelected == Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll)
 				{
 					incidenceTxt = "All";
 				}

--- a/BenMAP/BatchCommonClass.cs
+++ b/BenMAP/BatchCommonClass.cs
@@ -1098,6 +1098,7 @@ namespace BenMAP
 								CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 								CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold;
 								CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
+								CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 								CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction = new List<CRSelectFunction>();
 								for (int i = 0; i < CommonClass.BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue.Count; i++)
 								{

--- a/BenMAP/BenMap.cs
+++ b/BenMAP/BenMap.cs
@@ -1576,6 +1576,8 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 					CommonClass.BaseControlCRSelectFunction = null;
 					CommonClass.BaseControlCRSelectFunctionCalculateValue = null;
 					CommonClass.ValuationMethodPoolingAndAggregation = null;
+					CommonClass.incidenceAvgSelected = ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
+					ConfigurationCommonClass.incidenceAvgSelected = ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 					GC.Collect();
 					CommonClass.LoadBenMAPProject(openfile.FileName);
 					BenMAP_Load(this, null);
@@ -1595,6 +1597,7 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 						CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 						CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold;
 						CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
+						CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 						CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction = new List<CRSelectFunction>();
 						for (int i = 0; i < CommonClass.BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue.Count; i++)
 						{
@@ -2562,6 +2565,7 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 									CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 									CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold;
 									CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
+									CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 									CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction = new List<CRSelectFunction>();
 									CommonClass.MainSetup = CommonClass.getBenMAPSetupFromID(CommonClass.BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID);
 
@@ -2806,6 +2810,7 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 									CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 									CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold;
 									CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
+									CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 									CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction = new List<CRSelectFunction>();
 									CommonClass.MainSetup = CommonClass.getBenMAPSetupFromID(CommonClass.BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID);
 
@@ -2916,6 +2921,7 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 								CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 								CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold;
 								CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
+								CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 								CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction = new List<CRSelectFunction>();
 								CommonClass.MainSetup = CommonClass.getBenMAPSetupFromID(CommonClass.BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID);
 
@@ -3641,6 +3647,8 @@ SELECT SHAPEFILENAME FROM REGULARGRIDDEFINITIONDETAILS where griddefinitionid = 
 			CommonClass.CRRunInPointMode = baseControlCRSelectFunction.CRRunInPointMode;
 			CommonClass.CRThreshold = baseControlCRSelectFunction.CRThreshold;
 			CommonClass.CRSeeds = baseControlCRSelectFunction.CRSeeds;
+			CommonClass.incidenceAvgSelected = baseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
+			ConfigurationCommonClass.incidenceAvgSelected = baseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 			CommonClass.BenMAPPopulation = baseControlCRSelectFunction.BenMAPPopulation;
 			CommonClass.GBenMAPGrid = baseControlCRSelectFunction.BaseControlGroup.First().GridType;
 			if (baseControlCRSelectFunction.RBenMapGrid != null)
@@ -6731,7 +6739,8 @@ Color.FromArgb(255, 255, 166), 45.0F);
 					CommonClass.BenMAPPopulation = null;
 					CommonClass.BaseControlCRSelectFunction = null; CommonClass.BaseControlCRSelectFunctionCalculateValue = null;
 					CommonClass.lstIncidencePoolingAndAggregation = null;
-
+					CommonClass.incidenceAvgSelected = ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
+					ConfigurationCommonClass.incidenceAvgSelected = ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 					CommonClass.IncidencePoolingResult = null;
 					CommonClass.ValuationMethodPoolingAndAggregation = null;
 					CommonClass.BaseControlCRSelectFunction = null;
@@ -6756,6 +6765,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 						CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 						CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold;
 						CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
+						CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 						CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction = new List<CRSelectFunction>();
 						for (int i = 0; i < CommonClass.BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue.Count; i++)
 						{
@@ -6947,7 +6957,8 @@ Color.FromArgb(255, 255, 166), 45.0F);
 					CommonClass.CRThreshold = 0;
 					CommonClass.CRLatinHypercubePoints = 20;
 					CommonClass.CRRunInPointMode = false;
-
+					CommonClass.incidenceAvgSelected = ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
+					ConfigurationCommonClass.incidenceAvgSelected = ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 					CommonClass.BenMAPPopulation = null;
 
 					CommonClass.BaseControlCRSelectFunction = null;
@@ -11908,6 +11919,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 										bc.RBenMapGrid = cfgrFunctionCV.RBenMapGrid;
 										bc.BenMAPPopulation = cfgrFunctionCV.BenMAPPopulation;
 										bc.BaseControlGroup = cfgrFunctionCV.BaseControlGroup;
+										bc.incidenceAvgSelected = cfgrFunctionCV.incidenceAvgSelected; //YY: 539
 										List<CRSelectFunction> lstCRSelectFunction = new List<CRSelectFunction>();
 										foreach (CRSelectFunctionCalculateValue crfc in cfgrFunctionCV.lstCRSelectFunctionCalculateValue)
 										{

--- a/BenMAP/CommonClass.cs
+++ b/BenMAP/CommonClass.cs
@@ -546,7 +546,7 @@ namespace BenMAP
 		public static BenMAPGrid GBenMAPGrid; public static List<BaseControlGroup> LstBaseControlGroup; public static double CRThreshold = 0; public static int CRLatinHypercubePoints = 20; public static bool CRRunInPointMode = false; public static int CRSeeds = 1; public static int CRDefaultMonteCarloIterations = 10000; public static BenMAPPopulation BenMAPPopulation;
 		public static List<GridRelationship> LstCurrentGridRelationship; public static string CurrentStat;
 		public static List<string> LstAsynchronizationStates;
-
+		public static Configuration.ConfigurationCommonClass.incidenceAveraging incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 		public static Dictionary<string, Dictionary<string, float>> DicPopulationAgeInCache = new Dictionary<string, Dictionary<string, float>>();
 
 		private static List<GridRelationship> lstGridRelationshipAll;
@@ -2469,6 +2469,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 					benMAPProject.GBenMAPGrid = GBenMAPGrid; benMAPProject.LstBaseControlGroup = LstBaseControlGroup; benMAPProject.CRThreshold = CRThreshold; benMAPProject.CRLatinHypercubePoints = CRLatinHypercubePoints; benMAPProject.CRRunInPointMode = CRRunInPointMode; benMAPProject.CRDefaultMonteCarloIterations = CRDefaultMonteCarloIterations; benMAPProject.CRSeeds = CRSeeds;
 					benMAPProject.BenMAPPopulation = BenMAPPopulation;
 					benMAPProject.lstPollutantAll = lstPollutantAll;
+					benMAPProject.incidenceAvgSelected = incidenceAvgSelected; //YY: 539
 				}
 				benMAPProject.IncidencePoolingAndAggregationAdvance = IncidencePoolingAndAggregationAdvance;
 				benMAPProject.BenMAPPopulation = BenMAPPopulation; if (File.Exists(strFile))
@@ -2557,6 +2558,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 			{
 				CommonClass.LstPollutant = null; CommonClass.RBenMAPGrid = null;
 				CommonClass.GBenMAPGrid = null; CommonClass.LstBaseControlGroup = null; CommonClass.CRThreshold = 0; CommonClass.CRLatinHypercubePoints = 20; CommonClass.CRRunInPointMode = false;
+				CommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 				CommonClass.BenMAPPopulation = null;
 				if (CommonClass.BaseControlCRSelectFunction != null)
 				{
@@ -2698,6 +2700,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 					CommonClass.BaseControlCRSelectFunction.CRSeeds = CommonClass.BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 					BaseControlCRSelectFunction.CRDefaultMonteCarloIterations = BaseControlCRSelectFunctionCalculateValue.CRDefaultMonteCarloIterations;
 					BaseControlCRSelectFunction.CRThreshold = BaseControlCRSelectFunctionCalculateValue.CRThreshold;
+					BaseControlCRSelectFunction.incidenceAvgSelected = BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 					if (BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue != null)
 					{
 						BaseControlCRSelectFunction.lstCRSelectFunction = BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue.Select(p => p.CRSelectFunction).ToList();
@@ -2705,6 +2708,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 
 					ManageSetup = getBenMAPSetupFromID(BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID); MainSetup = getBenMAPSetupFromID(BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID); LstPollutant = BaseControlCRSelectFunction.BaseControlGroup.Select(p => p.Pollutant).ToList(); RBenMAPGrid = BaseControlCRSelectFunction.RBenMapGrid;
 					GBenMAPGrid = BaseControlCRSelectFunction.BaseControlGroup.First().GridType; LstBaseControlGroup = BaseControlCRSelectFunction.BaseControlGroup; CRThreshold = BaseControlCRSelectFunction.CRThreshold; CRLatinHypercubePoints = BaseControlCRSelectFunction.CRLatinHypercubePoints; CRRunInPointMode = BaseControlCRSelectFunction.CRRunInPointMode; CRSeeds = BaseControlCRSelectFunction.CRSeeds;
+					incidenceAvgSelected = BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 					BenMAPPopulation = BaseControlCRSelectFunction.BenMAPPopulation;
 				}
 				else if (benMAPProject.BaseControlCRSelectFunctionCalculateValue != null)
@@ -2721,6 +2725,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 					BaseControlCRSelectFunction.CRSeeds = BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 					BaseControlCRSelectFunction.CRDefaultMonteCarloIterations = BaseControlCRSelectFunctionCalculateValue.CRSeeds;
 					BaseControlCRSelectFunction.CRThreshold = BaseControlCRSelectFunctionCalculateValue.CRThreshold;
+					BaseControlCRSelectFunction.incidenceAvgSelected = BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 					if (BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue != null)
 					{
 						BaseControlCRSelectFunction.lstCRSelectFunction = BaseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue.Select(p => p.CRSelectFunction).ToList();
@@ -2729,6 +2734,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 					ManageSetup = getBenMAPSetupFromID(BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID); MainSetup = getBenMAPSetupFromID(BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID); LstPollutant = BaseControlCRSelectFunction.BaseControlGroup.Select(p => p.Pollutant).ToList();
 					RBenMAPGrid = BaseControlCRSelectFunctionCalculateValue.RBenMapGrid;
 					GBenMAPGrid = BaseControlCRSelectFunction.BaseControlGroup.First().GridType; LstBaseControlGroup = BaseControlCRSelectFunction.BaseControlGroup; CRThreshold = BaseControlCRSelectFunction.CRThreshold; CRLatinHypercubePoints = BaseControlCRSelectFunction.CRLatinHypercubePoints; CRDefaultMonteCarloIterations = BaseControlCRSelectFunction.CRDefaultMonteCarloIterations; CRRunInPointMode = BaseControlCRSelectFunction.CRRunInPointMode; CRSeeds = BaseControlCRSelectFunction.CRSeeds;
+					incidenceAvgSelected = BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 					BenMAPPopulation = BaseControlCRSelectFunction.BenMAPPopulation;
 				}
 				else if (benMAPProject.BaseControlCRSelectFunction != null)
@@ -2736,6 +2742,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 					BaseControlCRSelectFunction = benMAPProject.BaseControlCRSelectFunction;
 					ManageSetup = getBenMAPSetupFromID(BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID); MainSetup = getBenMAPSetupFromID(BaseControlCRSelectFunction.BaseControlGroup.First().GridType.SetupID); LstPollutant = BaseControlCRSelectFunction.BaseControlGroup.Select(p => p.Pollutant).ToList(); RBenMAPGrid = BaseControlCRSelectFunction.RBenMapGrid;
 					GBenMAPGrid = BaseControlCRSelectFunction.BaseControlGroup.First().GridType; LstBaseControlGroup = BaseControlCRSelectFunction.BaseControlGroup; CRThreshold = BaseControlCRSelectFunction.CRThreshold; CRLatinHypercubePoints = BaseControlCRSelectFunction.CRLatinHypercubePoints; CRDefaultMonteCarloIterations = BaseControlCRSelectFunction.CRDefaultMonteCarloIterations; CRRunInPointMode = BaseControlCRSelectFunction.CRRunInPointMode; CRSeeds = BaseControlCRSelectFunction.CRSeeds;
+					incidenceAvgSelected = BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 					BenMAPPopulation = BaseControlCRSelectFunction.BenMAPPopulation;
 				}
 				else
@@ -2747,7 +2754,7 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 						LstBaseControlGroup = benMAPProject.LstBaseControlGroup;
 					}
 					CRThreshold = benMAPProject.CRThreshold; CRLatinHypercubePoints = benMAPProject.CRLatinHypercubePoints; CRRunInPointMode = benMAPProject.CRRunInPointMode; CRSeeds = benMAPProject.CRSeeds;
-
+					incidenceAvgSelected = BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 					BenMAPPopulation = benMAPProject.BenMAPPopulation != null ? benMAPProject.BenMAPPopulation : null;
 					lstPollutantAll = benMAPProject.lstPollutantAll;
 				}
@@ -3080,6 +3087,8 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 		public ValuationMethodPoolingAndAggregation ValuationMethodPoolingAndAggregation;
 		[ProtoMember(19)]
 		public int CRDefaultMonteCarloIterations = 10000;
+		[ProtoMember(20)]
+		public Configuration.ConfigurationCommonClass.incidenceAveraging incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 	}
 
 	[Serializable]
@@ -4035,6 +4044,8 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 		public int CRDefaultMonteCarloIterations = 10000;
 		[ProtoMember(12)]
 		public BenMAPSetup Setup;
+		[ProtoMember(13)]
+		public Configuration.ConfigurationCommonClass.incidenceAveraging incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 	}
 
 	[Serializable]
@@ -4067,6 +4078,8 @@ other.Features[iotherFeature].Geometry.Distance(new Point(selfFeature.Geometry.E
 		public int CRDefaultMonteCarloIterations = 10000;
 		[ProtoMember(13)]
 		public BenMAPSetup Setup;
+		[ProtoMember(14)]
+		public Configuration.ConfigurationCommonClass.incidenceAveraging incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll; //YY: 539
 	}
 
 

--- a/BenMAP/Configuration/ConfigurationCommonClass.cs
+++ b/BenMAP/Configuration/ConfigurationCommonClass.cs
@@ -41,7 +41,7 @@ namespace BenMAP.Configuration
 
 
 		// global variable to hold user selection of averaging type
-		public static incidenceAveraging indidenceAvgSelected = incidenceAveraging.averageAll;
+		public static incidenceAveraging incidenceAvgSelected = incidenceAveraging.averageAll;
 
 		public static void ClearCRSelectFunctionCalculateValueLHS(ref CRSelectFunctionCalculateValue cRSelectFunctionCalculateValue)
 		{
@@ -88,7 +88,7 @@ namespace BenMAP.Configuration
 				copy.CRRunInPointMode = baseControlCRSelectFunctionCalculateValue.CRRunInPointMode;
 				copy.CRThreshold = baseControlCRSelectFunctionCalculateValue.CRThreshold;
 				copy.RBenMapGrid = baseControlCRSelectFunctionCalculateValue.RBenMapGrid;
-
+				copy.incidenceAvgSelected = baseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
 				copy.lstCRSelectFunctionCalculateValue = new List<CRSelectFunctionCalculateValue>();
 				List<float> lstd = new List<float>();
 				foreach (CRSelectFunctionCalculateValue crr in baseControlCRSelectFunctionCalculateValue.lstCRSelectFunctionCalculateValue)
@@ -324,7 +324,7 @@ namespace BenMAP.Configuration
 				copy.CRThreshold = baseControlCRSelectFunction.CRThreshold;
 				copy.RBenMapGrid = baseControlCRSelectFunction.RBenMapGrid;
 				copy.lstCRSelectFunction = baseControlCRSelectFunction.lstCRSelectFunction;
-
+				copy.incidenceAvgSelected = baseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 
 				if (File.Exists(strFile))
 					File.Delete(strFile);
@@ -2348,7 +2348,7 @@ new Meta.Numerics.Statistics.Distributions.CauchyDistribution(crSelectFunction.B
 				string strGender = "";
 				// this is performing a mapping from incidence age bins to population age bins -AS
 				// BF-531 - check to see if user wants to use average or filtered incidence rates
-				if (ConfigurationCommonClass.indidenceAvgSelected != incidenceAveraging.averageAll)
+				if (ConfigurationCommonClass.incidenceAvgSelected != incidenceAveraging.averageAll)
 				{
 					// add filter for race
 					//strRace = " and (b.RaceID=6)";

--- a/BenMAP/Configuration/HealthImpactFunctions.cs
+++ b/BenMAP/Configuration/HealthImpactFunctions.cs
@@ -86,6 +86,7 @@ namespace BenMAP
 				BaseControlCRSelectFunctionOld.CRRunInPointMode = CommonClass.BaseControlCRSelectFunction.CRRunInPointMode;
 				BaseControlCRSelectFunctionOld.CRThreshold = CommonClass.BaseControlCRSelectFunction.CRThreshold;
 				BaseControlCRSelectFunctionOld.RBenMapGrid = CommonClass.BaseControlCRSelectFunction.RBenMapGrid;
+				BaseControlCRSelectFunctionOld.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 				BaseControlCRSelectFunctionOld.lstCRSelectFunction = new List<CRSelectFunction>();
 				foreach (CRSelectFunction cr in CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction)
 				{
@@ -1183,6 +1184,7 @@ namespace BenMAP
 					CommonClass.BaseControlCRSelectFunction.CRRunInPointMode = CommonClass.CRRunInPointMode;
 					CommonClass.BaseControlCRSelectFunction.CRThreshold = CommonClass.CRThreshold;
 					CommonClass.BaseControlCRSelectFunction.RBenMapGrid = CommonClass.RBenMAPGrid;
+					CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = CommonClass.incidenceAvgSelected; //YY: 539
 					CommonClass.BaseControlCRSelectFunction.BenMAPPopulation = CommonClass.BenMAPPopulation;
 				}
 				dtRunStart = DateTime.Now;
@@ -1208,7 +1210,8 @@ namespace BenMAP
 					CommonClass.CRRunInPointMode = CommonClass.BaseControlCRSelectFunction.CRRunInPointMode;
 					CommonClass.CRThreshold = CommonClass.BaseControlCRSelectFunction.CRThreshold;
 					CommonClass.GBenMAPGrid = CommonClass.BaseControlCRSelectFunction.BaseControlGroup.First().GridType;
-
+					CommonClass.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
+					Configuration.ConfigurationCommonClass.incidenceAvgSelected = CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 				}
 				CommonClass.BaseControlCRSelectFunctionCalculateValue = new BaseControlCRSelectFunctionCalculateValue();
 				CommonClass.BaseControlCRSelectFunctionCalculateValue.BaseControlGroup = CommonClass.BaseControlCRSelectFunction.BaseControlGroup;
@@ -1218,6 +1221,7 @@ namespace BenMAP
 				CommonClass.BaseControlCRSelectFunctionCalculateValue.CRRunInPointMode = CommonClass.CRRunInPointMode;
 				CommonClass.BaseControlCRSelectFunctionCalculateValue.CRThreshold = CommonClass.CRThreshold;
 				CommonClass.BaseControlCRSelectFunctionCalculateValue.RBenMapGrid = CommonClass.RBenMAPGrid;
+				CommonClass.BaseControlCRSelectFunctionCalculateValue.incidenceAvgSelected = CommonClass.incidenceAvgSelected; //YY: 539
 				CommonClass.BaseControlCRSelectFunctionCalculateValue.BenMAPPopulation = CommonClass.BenMAPPopulation;
 				CommonClass.BaseControlCRSelectFunctionCalculateValue.Version = "BenMAP-CE " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString().Substring(0, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString().Count() - 2);
 
@@ -2246,7 +2250,7 @@ namespace BenMAP
 				bc.CRThreshold = CommonClass.CRThreshold;
 				bc.CRSeeds = CommonClass.CRSeeds;
 				bc.RBenMapGrid = CommonClass.RBenMAPGrid;
-
+				bc.incidenceAvgSelected = CommonClass.incidenceAvgSelected; //YY: 539
 				bc.BenMAPPopulation = CommonClass.BenMAPPopulation;
 				bc.BaseControlGroup = CommonClass.LstBaseControlGroup;
 				bc.lstCRSelectFunction = olvSelected.Objects as List<CRSelectFunction>;
@@ -2305,12 +2309,14 @@ namespace BenMAP
 			(frm as LatinHypercubePoints).IsRunInPointMode = CommonClass.CRRunInPointMode;
 			(frm as LatinHypercubePoints).Threshold = CommonClass.CRThreshold;
 			(frm as LatinHypercubePoints).DefaultMonteCarloIterations = CommonClass.CRDefaultMonteCarloIterations;
+			//YY: 539 incidenceAvgSelected radio buttons are loaded at form_Load using ConfigurationCommonClass.incidenceAvgSelected
 			DialogResult rtn = frm.ShowDialog();
 			if (rtn != DialogResult.OK) { return; }
 			CommonClass.CRLatinHypercubePoints = (frm as LatinHypercubePoints).LatinHypercubePointsCount;
 			CommonClass.CRRunInPointMode = (frm as LatinHypercubePoints).IsRunInPointMode;
 			CommonClass.CRThreshold = (frm as LatinHypercubePoints).Threshold;
 			CommonClass.CRDefaultMonteCarloIterations = (frm as LatinHypercubePoints).DefaultMonteCarloIterations;
+			//YY: 539 CommonClass.incidenceAvgSelected is updated at btn_OK 539
 		}
 		private void olvSelected_KeyDown(object sender, KeyEventArgs e)
 		{

--- a/BenMAP/Configuration/LatinHypercubePoints.cs
+++ b/BenMAP/Configuration/LatinHypercubePoints.cs
@@ -71,7 +71,8 @@ namespace BenMAP
 					txtRandomSeed.Enabled = true;
 				}
 				// set check boxes for incidence averaging from global variable
-				switch (Configuration.ConfigurationCommonClass.indidenceAvgSelected)
+				// note that unlike isRunInPointMode, incidenceAvgSelected was originally made as a global variable but not a property of LatinHypercubePoints. 539
+				switch (Configuration.ConfigurationCommonClass.incidenceAvgSelected)
 				{
 					case Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll:
 						rbAvg.Checked = true;
@@ -97,6 +98,21 @@ namespace BenMAP
 				{
 					CommonClass.BaseControlCRSelectFunction.lstCRSelectFunction[i].lstLatinPoints = null;
 				}
+			}
+			//YY: 539
+			if (CommonClass.BaseControlCRSelectFunction != null)
+			{
+				if (rbAvg.Checked)
+				{
+					Configuration.ConfigurationCommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll;
+					CommonClass.incidenceAvgSelected= Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll;
+				}
+				else if (rbFiltered.Checked)
+				{
+					Configuration.ConfigurationCommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageFiltered;
+					CommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageFiltered;
+				}
+				CommonClass.BaseControlCRSelectFunction.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAvgSelected;
 			}
 			try
 			{
@@ -165,14 +181,16 @@ namespace BenMAP
 
 		private void rbFiltered_CheckedChanged(object sender, EventArgs e)
 		{
-			if (rbFiltered.Checked) Configuration.ConfigurationCommonClass.indidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageFiltered;
-			else Configuration.ConfigurationCommonClass.indidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll;
+			//YY: 539 Values should not be saved in configuration until OK button is clicked 
+			//if (rbFiltered.Checked) Configuration.ConfigurationCommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageFiltered;
+			//else Configuration.ConfigurationCommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll;
 		}
 
 		private void rbAvg_CheckedChanged(object sender, EventArgs e)
 		{
-			if (rbFiltered.Checked) Configuration.ConfigurationCommonClass.indidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageFiltered;
-			else Configuration.ConfigurationCommonClass.indidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll;
+			//YY: 539 Values should not be saved in configuration until OK button is clicked 
+			//if (rbFiltered.Checked) Configuration.ConfigurationCommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageFiltered;
+			//else Configuration.ConfigurationCommonClass.incidenceAvgSelected = Configuration.ConfigurationCommonClass.incidenceAveraging.averageAll;
 		}
 	}
 }

--- a/BenMAP/Configuration/OpenExistingConfiguration.cs
+++ b/BenMAP/Configuration/OpenExistingConfiguration.cs
@@ -97,7 +97,12 @@ namespace BenMAP
 							return;
 						}
 					}
-
+					if (baseControlCRSelectFunctionCalculateValue != null) 
+					{
+						Configuration.ConfigurationCommonClass.incidenceAvgSelected = baseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
+						CommonClass.incidenceAvgSelected = baseControlCRSelectFunctionCalculateValue.incidenceAvgSelected; //YY: 539
+					}
+					
 					this.DialogResult = System.Windows.Forms.DialogResult.OK;
 				}
 				else if (strCRPath.Substring(strCRPath.Length - 4, 4) == "cfgx" && rbtOpenCfg.Checked)
@@ -126,6 +131,7 @@ namespace BenMAP
 					}
 					CommonClass.ClearAllObject();
 					CommonClass.BaseControlCRSelectFunction = baseControlCRSelectFunction;
+					
 					this.DialogResult = System.Windows.Forms.DialogResult.OK;
 
 					if (baseControlCRSelectFunction == null)
@@ -133,7 +139,8 @@ namespace BenMAP
 						MessageBox.Show(err);
 						return;
 					}
-
+					Configuration.ConfigurationCommonClass.incidenceAvgSelected = baseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
+					CommonClass.incidenceAvgSelected = baseControlCRSelectFunction.incidenceAvgSelected; //YY: 539
 
 				}
 				if (CommonClass.LstUpdateCRFunction != null)


### PR DESCRIPTION
BENMAP-539 Retain advanced selection of option 2 (filtered incidence). The settings should retain when loading a saved cfgx, cfgrx, apvx, avprx or a project file.