### PR TITLE
Develop yyang

### DIFF
--- a/BenMAP/BatchCommonClass.cs
+++ b/BenMAP/BatchCommonClass.cs
@@ -1033,6 +1033,14 @@ namespace BenMAP
 									{
 										benMAP.cflstResult.Where(p => p.FieldName == "Percentiles").First().isChecked = true;
 									}
+									else
+									{
+										//BenMAP-543. Percentiles fields are required to generate "Formatted Results" fields, which were added to commandline GENERATE REPORT CFGR output since BENMAP530. 
+										//Therefore, Percentiles fileds are always needed when using GENERATE REPORT CFGR command.
+										//In the future, it is better to either update the user menu (v April 2021) to incidate that Percentiles will always be included in report, 
+										//or update the code so that although "Formatted Results" fields are calculated using Percentiles fields, the output cvs will not include Percentiles fields. 
+										benMAP.cflstResult.Where(p => p.FieldName == "Percentiles").First().isChecked = true;
+									}
 								}
 								benMAP._tableObject = bControlCR.lstCRSelectFunctionCalculateValue;
 								benMAP.btnTableOutput_Click(null, null);
@@ -1536,6 +1544,13 @@ namespace BenMAP
 											{
 												benMAP.IncidencelstResult.Where(p => p.FieldName == "Percentiles").First().isChecked = true;
 											}
+											else
+											{
+												//BenMAP-543. Percentiles fields are USUALLY required to generate "Formatted Results" fields, which were added to commandline GENERATE REPORT CFGR output since BENMAP530. 
+												//Currently for command GENERATE REPORT APVR with parameter -ResultType = PooledIncidence, Percentiles fields are always added to export no matter if it's listed in "-ResultFields" or not.
+												//To be consistent with GENERATE REPORT APVR with parameter -ResultType = PooledValuation and GENERATE REPORT CFGR, we make this field always show in batch report. 
+												benMAP.IncidencelstResult.Where(p => p.FieldName == "Percentiles").First().isChecked = true;
+											}
 										}
 										break;
 									case "PooledValuation":
@@ -1704,6 +1719,14 @@ namespace BenMAP
 											}
 											if (strTemp.Contains("percentiles"))
 											{
+												benMAP.apvlstResult.Where(p => p.FieldName == "Percentiles").First().isChecked = true;												
+											}
+											else
+											{
+												//BenMAP-543. Percentiles fields are required to generate "Formatted Results" fields, which were added to commandline GENERATE REPORT APVR output since BENMAP530. 
+												//Therefore, Percentiles fileds are always needed when using GENERATE REPORT APVR command (with ResultType=PooledIncidence).
+												//note that the user menu (v April 2021) does not have parameter "-ResultFields" for command GENERATE REPORT APVR, but the code has it. 
+												//in the future, we should either update the user manual or ignore "-ResultFields" input for command GENERATE REPORT APVR
 												benMAP.apvlstResult.Where(p => p.FieldName == "Percentiles").First().isChecked = true;
 											}
 										}
@@ -1727,22 +1750,27 @@ namespace BenMAP
 										break;
 									case "PooledIncidence":
 										List<AllSelectCRFunction> lstCR = new List<AllSelectCRFunction>(); //In order to display version and dataset in batch mode, must pass the AllSelectCRFunction, not the CRSelectFunctionCalculateValue--[BenMAP 434, MP]
+										Dictionary<AllSelectCRFunction, string> dicPooledIncidence = new Dictionary<AllSelectCRFunction, string>(); //BenMAP-543 use the new export function to include pooling name and grid definition.
+
 										benMAP.LoadAllIncidencePooling(ref benMAP.dicIncidencePoolingAndAggregation, ref benMAP.dicIncidencePoolingAndAggregationUnPooled);
-										foreach (KeyValuePair<AllSelectCRFunction, string> keyValueCR in benMAP.dicIncidencePoolingAndAggregation)
-										{
-											AllSelectCRFunction cr = keyValueCR.Key;
+										//foreach (KeyValuePair<AllSelectCRFunction, string> keyValueCR in benMAP.dicIncidencePoolingAndAggregation)
+										//{
+										//	AllSelectCRFunction cr = keyValueCR.Key;
 
-											if (cr.CRSelectFunctionCalculateValue == null || cr.CRSelectFunctionCalculateValue.CRCalculateValues == null || cr.CRSelectFunctionCalculateValue.CRCalculateValues.Count == 0)
-											{
-												continue;
-											}
-											else
-											{
-												lstCR.Add(cr);  //In order to display version and dataset in batch mode, must pass the AllSelectCRFunction, not the CRSelectFunctionCalculateValue--[BenMAP 434, MP]
-											}
+										//	if (cr.CRSelectFunctionCalculateValue == null || cr.CRSelectFunctionCalculateValue.CRCalculateValues == null || cr.CRSelectFunctionCalculateValue.CRCalculateValues.Count == 0)
+										//	{
+										//		continue;
+										//	}
+										//	else
+										//	{
+										//		lstCR.Add(cr);  //In order to display version and dataset in batch mode, must pass the AllSelectCRFunction, not the CRSelectFunctionCalculateValue--[BenMAP 434, MP]
+										//	}
 
-										}
-										benMAP._tableObject = lstCR;
+										//}
+										dicPooledIncidence = benMAP.dicIncidencePoolingAndAggregation; //BenMAP-543
+
+										//benMAP._tableObject = lstCR;
+										benMAP._tableObject = dicPooledIncidence; //BenMAP-543
 										benMAP.tabCtlReport.SelectedIndex = 1;
 										benMAP.btnTableOutput_Click(null, null);
 

--- a/BenMAP/BatchCommonClass.cs
+++ b/BenMAP/BatchCommonClass.cs
@@ -611,6 +611,7 @@ namespace BenMAP
 							if (batchAPV.DollarYear != null && batchAPV.DollarYear != "")
 								//valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.IncomeGrowthYear = Convert.ToInt32(batchAPV.DollarYear);
 								valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.CurrencyYear = Convert.ToInt32(batchAPV.DollarYear);
+							//Batch parameter -DollarYear is Inflation Currency Year.
 							//Income growth year is different from currency year. Income growth year should remain what is specified in APV (*.apvx) file. 
 							if (batchAPV.RandomSeed != -1)
 								valuationMethodPoolingAndAggregation.IncidencePoolingAndAggregationAdvance.RandomSeed = batchAPV.RandomSeed.ToString();

--- a/BenMAP/BenMap.cs
+++ b/BenMAP/BenMap.cs
@@ -6045,6 +6045,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 							}
 
 						}
+
 						if ((apvlstResult == null || apvlstResult.Last().isChecked) && lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile != null)
 						{
 							i = 0;
@@ -6055,20 +6056,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 								i++;
 							}
 						}
-						else if (isBatch && lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile != null)
-						{
-							//BENMAP-543 in batch mode, apvlstResult.Last(), which is the field "percentile" is always unchecked but we would always want to include percentile in report.
-							i = 0;
-							while (i < lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())
-							{
-
-								dt.Columns.Add("Percentile " + ((Convert.ToDouble(i + 1) * 100.00 / Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()) - (100.00 / (2 * Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()))))), typeof(double));
-								i++;
-							}
-
-						}
-
-
+						
 						foreach (AllSelectValuationMethodAndValue allSelectValuationMethodAndValue in lstallSelectValuationMethodAndValue)
 						{
 							foreach (APVValueAttribute apvx in allSelectValuationMethodAndValue.lstAPVValueAttributes)
@@ -6112,6 +6100,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 									dr["Variance"] = apvx.Variance;
 
 								}
+								
 								else
 								{
 									foreach (FieldCheck fieldCheck in apvlstResult)
@@ -6133,19 +6122,7 @@ Color.FromArgb(255, 255, 166), 45.0F);
 										i++;
 									}
 								}
-								else if (isBatch && lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile != null)
-								{
-									//BENMAP-543 
-									i = 0;
-									while (i < lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())
-									{
-										dr["Percentile " + ((Convert.ToDouble(i + 1) * 100.00 / Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()) - (100.00 / (2 * Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())))))] = apvx.LstPercentile[i];
-										i++;
-									}
-
-								}
-
-
+								
 								dt.Rows.Add(dr);
 							}
 						}

--- a/BenMAP/BenMap.cs
+++ b/BenMAP/BenMap.cs
@@ -6055,6 +6055,18 @@ Color.FromArgb(255, 255, 166), 45.0F);
 								i++;
 							}
 						}
+						else if (isBatch && lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile != null)
+						{
+							//BENMAP-543 in batch mode, apvlstResult.Last(), which is the field "percentile" is always unchecked but we would always want to include percentile in report.
+							i = 0;
+							while (i < lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())
+							{
+
+								dt.Columns.Add("Percentile " + ((Convert.ToDouble(i + 1) * 100.00 / Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()) - (100.00 / (2 * Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()))))), typeof(double));
+								i++;
+							}
+
+						}
 
 
 						foreach (AllSelectValuationMethodAndValue allSelectValuationMethodAndValue in lstallSelectValuationMethodAndValue)
@@ -6120,6 +6132,17 @@ Color.FromArgb(255, 255, 166), 45.0F);
 										dr["Percentile " + ((Convert.ToDouble(i + 1) * 100.00 / Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()) - (100.00 / (2 * Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())))))] = apvx.LstPercentile[i];
 										i++;
 									}
+								}
+								else if (isBatch && lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile != null)
+								{
+									//BENMAP-543 
+									i = 0;
+									while (i < lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())
+									{
+										dr["Percentile " + ((Convert.ToDouble(i + 1) * 100.00 / Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count()) - (100.00 / (2 * Convert.ToDouble(lstallSelectValuationMethodAndValue.First().lstAPVValueAttributes.First().LstPercentile.Count())))))] = apvx.LstPercentile[i];
+										i++;
+									}
+
 								}
 
 


### PR DESCRIPTION
BENMAP-543 Fix the issue when reporting pooled valuation results using command line

For both “GENERATE REPORT APVR“ and “GENERATE REPORT CFGR“, “Percentiles” field(s) are now always added to the report whether the -ResultFields parameter is used or not. 

I also found GENERATE REPORT CFGR is still using the old function to generate report. I hooked it with the new one so that field “Pooling Name” and “Grid Definition” fields will also be included in the report. 